### PR TITLE
Account for multi-line names when detecting prose

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,9 +86,10 @@ var prepareContext = function(ctx) {
       item.context.type = 'prose';
       item.context.line.end = item.context.line.start;
     }
-    // @@@ This breaks cases where a Sass block selector is more than 2 lines.
-    // https://github.com/oddbird/sassdoc-theme-herman/pull/71#pullrequestreview-46309820
-    if (item.context.line.start > item.commentRange.end + 2) {
+    // Consider it to be prose if it's separated from the next Sass block
+    // by any blank lines.
+    var lineCount = item.context.name.split('\n').length;
+    if (item.context.line.start > item.commentRange.end + lineCount) {
       item.context = {
         type: 'prose',
         line: item.commentRange

--- a/index.js
+++ b/index.js
@@ -88,7 +88,8 @@ var prepareContext = function(ctx) {
     }
     // Consider it to be prose if it's separated from the next Sass block
     // by any blank lines.
-    var lineCount = item.context.name.split('\n').length;
+    var name = item.context.origName || item.context.name;
+    var lineCount = name.split('\n').length;
     if (item.context.line.start > item.commentRange.end + lineCount) {
       item.context = {
         type: 'prose',
@@ -627,6 +628,27 @@ herman.annotations = [
             renderIframe(env, exampleItem, 'example');
           });
         });
+      }
+    };
+  },
+  /**
+   * Override `@name` annotation to preserve the original name
+   */
+  function name() {
+    return {
+      name: 'name',
+      multiple: false,
+      parse: function parse(text) {
+        return text.trim();
+      },
+      // Abuse the autofill feature to rewrite the `item.context`
+      autofill: function autofill(item) {
+        if (item.name) {
+          item.context.origName = item.context.name;
+          item.context.name = item.name;
+          // Cleanup
+          delete item.name;
+        }
       }
     };
   }

--- a/index.js
+++ b/index.js
@@ -631,6 +631,7 @@ herman.annotations = [
       }
     };
   },
+
   /**
    * Override `@name` annotation to preserve the original name
    */

--- a/templates/item/_item.j2
+++ b/templates/item/_item.j2
@@ -36,7 +36,7 @@
   {{ preview.icons(item) }}
   {{ preview.show_previews(
     data=sassjson,
-    name=item.context.name,
+    name=item.context.origName or item.context.name,
     args=item.preview
   ) }}
 </section>

--- a/templates/item/macros.j2
+++ b/templates/item/macros.j2
@@ -191,7 +191,7 @@
 
 
 {% macro scss_variable(item) -%}
-${{ item.context.name }}: {{ item.context.value }}{% if item.context.scope != 'private' %} !{{ item.context.scope }}{% endif %};
+${{ item.context.origName or item.context.name }}: {{ item.context.value }}{% if item.context.scope != 'private' %} !{{ item.context.scope }}{% endif %};
 {%- endmacro %}
 
 

--- a/templates/item/macros.j2
+++ b/templates/item/macros.j2
@@ -196,7 +196,7 @@ ${{ item.context.name }}: {{ item.context.value }}{% if item.context.scope != 'p
 
 
 {%- macro scss_css(item) -%}
-{{ item.context.name }} {
+{{ item.context.origName or item.context.name }} {
   {{ item.context.value }}
 }
 {%- endmacro -%}

--- a/test/test.js
+++ b/test/test.js
@@ -270,3 +270,25 @@ describe('example annotation', function() {
     });
   });
 });
+
+describe('name annotation', function() {
+  before(function() {
+    this.macro = theme.annotations[4](this.env);
+  });
+
+  describe('parse', function() {
+    it('trims text', function() {
+      assert.equal(this.macro.parse('foo '), 'foo');
+    });
+  });
+
+  describe('autofill', function() {
+    it('preserves original context name', function() {
+      var data = { name: 'foo', context: { name: 'bar' } };
+
+      this.macro.autofill(data);
+
+      assert.deepEqual(data, { context: { name: 'foo', origName: 'bar' } });
+    });
+  });
+});


### PR DESCRIPTION
This fixes the issue discussed at https://github.com/oddbird/sassdoc-theme-herman/pull/71#discussion_r124052871


![](https://s-media-cache-ak0.pinimg.com/236x/6e/40/ab/6e40ab6f683ec7302e0bc46cbe87eb92--funny-stuff-so-funny.jpg)
