### PR TITLE
Support SassDoc `googleAnalytics` and `trackingCode` options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Herman Changelog
 
 
+## Unreleased
+
+- NEW: Support SassDoc [`googleAnalytics`][googleAnalytics] and
+  [`trackingCode`][trackingCode] options --
+  [#215](https://github.com/oddbird/sassdoc-theme-herman/issues/215)
+
+[googleAnalytics]: http://sassdoc.com/customising-the-view/#google-analytics
+[trackingCode]: http://sassdoc.com/customising-the-view/#tracking-code
+
+
 ## 1.0.0-rc.6: 2017-12-04
 
 - BUGFIX: Fix search result page links.

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>
@@ -247,6 +251,12 @@
           
   <div class="text-block">
     <h1 id="herman-changelog">Herman Changelog</h1>
+<h2 id="unreleased">Unreleased</h2>
+<ul>
+<li>NEW: Support SassDoc <a href="http://sassdoc.com/customising-the-view/#google-analytics"><code>googleAnalytics</code></a> and
+<a href="http://sassdoc.com/customising-the-view/#tracking-code"><code>trackingCode</code></a> options –
+<a href="https://github.com/oddbird/sassdoc-theme-herman/issues/215">#215</a></li>
+</ul>
 <h2 id="1-0-0-rc-6-2017-12-04">1.0.0-rc.6: 2017-12-04</h2>
 <ul>
 <li>BUGFIX: Fix search result page<span class="widont">&nbsp;</span>links.</li>

--- a/docs/CONFIGURATION.html
+++ b/docs/CONFIGURATION.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/CONTRIBUTING.html
+++ b/docs/CONTRIBUTING.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/api_json-export.html
+++ b/docs/api_json-export.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/config-colors.html
+++ b/docs/config-colors.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/config-fonts.html
+++ b/docs/config-fonts.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/config-scale.html
+++ b/docs/config-scale.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/config-utils.html
+++ b/docs/config-utils.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/config-z-index.html
+++ b/docs/config-z-index.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/config_api-utilities.html
+++ b/docs/config_api-utilities.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/demo_colors.html
+++ b/docs/demo_colors.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/demo_examples.html
+++ b/docs/demo_examples.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/demo_fonts.html
+++ b/docs/demo_fonts.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/demo_icons.html
+++ b/docs/demo_icons.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/demo_sizes.html
+++ b/docs/demo_sizes.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/demo_test-sassdoc.html
+++ b/docs/demo_test-sassdoc.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/search.html
+++ b/docs/search.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/style-code.html
+++ b/docs/style-code.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/style-icons.html
+++ b/docs/style-icons.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/style-nav.html
+++ b/docs/style-nav.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/style-sections.html
+++ b/docs/style-sections.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/docs/style-typography.html
+++ b/docs/style-typography.html
@@ -13,6 +13,10 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  
+
+  
 </head>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" hidden>

--- a/templates/base.njk
+++ b/templates/base.njk
@@ -13,6 +13,23 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600|Source+Sans+Pro:400,400i,700,700i" rel="stylesheet">
 
   <link rel="stylesheet" href="assets/webpack/app_styles.min.css" />
+
+  {% if googleAnalytics %}
+    <!-- Global Site Tag (gtag.js) - Google Analytics -->
+    <script type="text/javascript" async src="https://www.googletagmanager.com/gtag/js?id={{ googleAnalytics }}"></script>
+    <script type="text/javascript">
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments)};
+      gtag('js', new Date());
+
+      gtag('config', '{{ googleAnalytics }}');
+    </script>
+  {% endif %}
+
+  {% if trackingCode %}
+    <!-- Custom trackingCode -->
+    {{ trackingCode|safe }}
+  {% endif %}
 </head>
 <body>
   {% include '_icons.svg' %}


### PR DESCRIPTION
Fixes #215.

![dog](https://i.pinimg.com/736x/6e/59/65/6e5965c3d8516a93f93dda2b9a976ed1.jpg)