### PR TITLE
Escape backslashes in herman-export string values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Unreleased
 
+- 🐛 BUGFIX: Escape backslashes in herman-export string values
 - 🚀 NEW: Add `sass.outputStyle` option (default: `expanded`) --
   [#263](https://github.com/oddbird/sassdoc-theme-herman/issues/263)
 - 🐛 BUGFIX: Fix bug if annotations try to access missing `env.herman` --

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -297,6 +297,7 @@
     <h1 id="herman-changelog">Herman Changelog</h1>
 <h2 id="unreleased">Unreleased</h2>
 <ul>
+<li>🐛 BUGFIX: Escape backslashes in herman-export string<span class="widont">&nbsp;</span>values</li>
 <li>🚀 NEW: Add <code>sass.outputStyle</code> option (default: <code>expanded</code>) –
 <a href="https://github.com/oddbird/sassdoc-theme-herman/issues/263">#263</a></li>
 <li>🐛 BUGFIX: Fix bug if annotations try to access missing <code>env.herman</code> –

--- a/docs/config_api-utilities.html
+++ b/docs/config_api-utilities.html
@@ -1993,6 +1993,41 @@ adding proof-quotes for length<span class="widont">&nbsp;</span>values.</p>
       <span class="item-type">@function</span>
       
         <a href="
+  config_api-utilities.html#function--_herman-escape-backslashes" class="item-name">_herman-escape-backslashes()</a>
+      
+      
+      
+      <span class="item-note">[private]</span>
+    </h4>
+
+    
+  </div>
+
+
+        
+      
+        
+        
+        
+
+        
+          
+          
+  
+  
+  
+  
+  
+  
+  
+  
+
+  
+  <div class="param-list">
+    <h4 class="param-title">
+      <span class="item-type">@function</span>
+      
+        <a href="
   config_api-utilities.html#function--_herman-escape-quotes" class="item-name">_herman-escape-quotes()</a>
       
       
@@ -2192,6 +2227,216 @@ adding proof-quotes for length<span class="widont">&nbsp;</span>values.</p>
   
     <div class="text-block">
       <p>Return a string, with internal quotes<span class="widont">&nbsp;</span>escaped.</p>
+
+      
+  
+
+      
+  
+
+      
+  
+
+    </div>
+  
+
+  </div>
+
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    
+  <div data-item-section="parameter">
+    
+      <h3 class="item-subtitle">
+        <span class="item-subtitle-main">Parameters</span>
+        
+      </h3>
+    
+
+    
+      
+        
+  
+  
+
+  
+  <div class="param-list">
+    <h4 class="param-title">
+      
+      
+        <span class="item-name">$string:</span>
+      
+      
+      <span class="value-type">(string)</span>
+      
+    </h4>
+
+    
+      
+      <div class="param-details text-block">
+        <p>The string to be<span class="widont">&nbsp;</span>manipulated</p>
+
+      </div>
+    
+  </div>
+
+
+      
+
+      
+  
+
+      
+  
+
+      
+  
+
+      
+  
+
+    
+  </div>
+
+  
+
+
+  
+  
+
+
+  
+  
+  
+  
+    
+    
+  
+    
+  <div data-item-section="used-by">
+    
+      <h3 class="item-subtitle">
+        <span class="item-subtitle-main">Used By</span>
+        
+      </h3>
+    
+
+    
+      
+      
+        
+
+        
+          
+          
+  
+  
+  
+  
+  
+  
+
+  
+  <div class="param-list">
+    <h4 class="param-title">
+      <span class="item-type">@function</span>
+      
+        <a href="
+  config_api-utilities.html#function--_herman-quote" class="item-name">_herman-quote()</a>
+      
+      
+      
+      <span class="item-note">[private]</span>
+    </h4>
+
+    
+  </div>
+
+
+        
+      
+    
+  </div>
+
+  
+
+  
+
+  
+  
+
+
+  
+  
+
+  
+  
+
+</section>
+
+  
+    
+    
+
+
+
+
+
+
+
+
+
+
+<section class="item" id="function--_herman-escape-backslashes">
+  
+    
+  
+  
+
+  
+  
+  
+  
+
+  <div data-item-section="header">
+    <h2 class="item-title">
+      
+        <span class="item-type">@function</span>
+      
+
+      
+        <a href="#function--_herman-escape-backslashes" class="item-name">_herman-escape-backslashes()</a>
+      
+
+      
+
+      
+        <span class="item-note">[private]</span>
+      
+    </h2>
+
+    
+  
+
+
+    
+    
+  
+  
+  
+  
+
+  
+    <div class="text-block">
+      <p>Return a string, with internal backslashes<span class="widont">&nbsp;</span>escaped.</p>
 
       
   

--- a/scss/utilities/_json-encode.scss
+++ b/scss/utilities/_json-encode.scss
@@ -95,6 +95,7 @@
 ///   The value to inspect and quote.
 @function _herman-quote($value) {
   $value: '#{$value}';
+  $value: _herman-escape-backslashes($value);
   $value: _herman-escape-quotes($value);
   @return '"#{$value}"';
 }
@@ -121,6 +122,35 @@
     $a: if($i > 1, str-slice($string, 1, $i - 1), '');
     $z: str-slice($string, $i + $n);
     $z: _herman-escape-quotes($z);
+
+    $return: $a + if($new, $new, '') + $z;
+  }
+
+  @return $return;
+}
+
+// Escape Backslashes
+// ------------------
+/// Return a string, with internal backslashes escaped.
+///
+/// @group config_api-utilities
+/// @access private
+///
+/// @param {string} $string -
+///   The string to be manipulated
+@function _herman-escape-backslashes($string) {
+  $return: $string;
+  $old: '\\';
+  $new: '\\\\';
+  $i: str-index($string, $old);
+  $n: str-length($old);
+
+  @if ($string == $old) {
+    $return: $new;
+  } @else if $i {
+    $a: if($i > 1, str-slice($string, 1, $i - 1), '');
+    $z: str-slice($string, $i + $n);
+    $z: _herman-escape-backslashes($z);
 
     $return: $a + if($new, $new, '') + $z;
   }

--- a/test/sass/utilities/_json-encode.scss
+++ b/test/sass/utilities/_json-encode.scss
@@ -49,6 +49,10 @@
       '"hello \\"world\\""'
     );
   }
+
+  @include it('returns escaped backslashes in strings') {
+    @include assert-equal(_herman-encode('hello\\world'), '"hello\\\\world"');
+  }
 }
 
 // Encode List
@@ -108,6 +112,17 @@
     @include assert-equal(
       _herman-escape-quotes('hello "world"'),
       'hello \\"world\\"'
+    );
+  }
+}
+
+// Escape Backslashes
+// ------------------
+@include describe('herman-escape-backslashes [function]') {
+  @include it('escapes backslashes in string') {
+    @include assert-equal(
+      _herman-escape-backslashes('hello\\world'),
+      'hello\\\\world'
     );
   }
 }


### PR DESCRIPTION
This fixes bugs with Windows-style paths, e.g.:

```scss
$local-font: (
  'name': 'rockingham',
  'regular': 'rockingham\\rockingham-regular-webfont',
  'formats': 'woff2' 'woff' 'ttf',
);
```

Will now be output as:

```scss
"regular": "rockingham\\rockingham-regular-webfont"
```

Instead of:

```scss
"regular": "rockingham\rockingham-regular-webfont"
```