### PR TITLE
Move node-sass to peerDependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Unreleased
 
 - 💥 BREAKING: Move `node-sass` to `peerDependencies`
+- 🐛 BUGFIX: Do not require `node-sass` if `@example scss` is not used
 
 
 ## 2.1.0: 2018-04-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Herman Changelog
 
 
+## Unreleased
+
+- 💥 BREAKING: Move `node-sass` to `peerDependencies`
+
+
 ## 2.1.0: 2018-04-02
 
 - 🚀 NEW: Add `sass.outputStyle` option (default: `expanded`) --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - 💥 BREAKING: Move `node-sass` to `peerDependencies`
 - 🐛 BUGFIX: Do not require `node-sass` if `@example scss` is not used
+- 🏠 INTERNAL: Upgrade dev dependencies
 
 
 ## 2.1.0: 2018-04-02

--- a/README.md
+++ b/README.md
@@ -43,8 +43,17 @@ and more.
 npm install sassdoc sassdoc-theme-herman
 ```
 
+Note: If you plan to use Herman to display samples of Sass/Scss code,
+`node-sass` is required as a `peerDependency`.
+If it's not already installed in your project,
+install it with Herman:
+
+```bash
+npm install node-sass
+```
+
 See the [SassDoc documentation](http://sassdoc.com/getting-started/)
-to install SassDoc and run it via various build tools.
+to run SassDoc via various build tools.
 Specify `herman` as the theme
 in your SassDoc options:
 

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -299,6 +299,7 @@
 <ul>
 <li>💥 BREAKING: Move <code>node-sass</code> to <code>peerDependencies</code></li>
 <li>🐛 BUGFIX: Do not require <code>node-sass</code> if <code>@example scss</code> is not<span class="widont">&nbsp;</span>used</li>
+<li>🏠 INTERNAL: Upgrade dev<span class="widont">&nbsp;</span>dependencies</li>
 </ul>
 <h2 id="2-1-0-2018-04-02">2.1.0: 2018-04-02</h2>
 <ul>

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -295,6 +295,10 @@
           
   <div class="text-block">
     <h1 id="herman-changelog">Herman Changelog</h1>
+<h2 id="unreleased">Unreleased</h2>
+<ul>
+<li>💥 BREAKING: Move <code>node-sass</code> to <code>peerDependencies</code></li>
+</ul>
 <h2 id="2-1-0-2018-04-02">2.1.0: 2018-04-02</h2>
 <ul>
 <li>🚀 NEW: Add <code>sass.outputStyle</code> option (default: <code>expanded</code>) –

--- a/docs/CHANGELOG.html
+++ b/docs/CHANGELOG.html
@@ -298,6 +298,7 @@
 <h2 id="unreleased">Unreleased</h2>
 <ul>
 <li>💥 BREAKING: Move <code>node-sass</code> to <code>peerDependencies</code></li>
+<li>🐛 BUGFIX: Do not require <code>node-sass</code> if <code>@example scss</code> is not<span class="widont">&nbsp;</span>used</li>
 </ul>
 <h2 id="2-1-0-2018-04-02">2.1.0: 2018-04-02</h2>
 <ul>

--- a/docs/api_json-export.html
+++ b/docs/api_json-export.html
@@ -1459,7 +1459,7 @@ and any additional arguments for the<span class="widont">&nbsp;</span>function</
       
       <pre class="hljs-pre"><code class="lang-scss">$brand-colors: (
   &#39;brand-blue&#39;: hsl(195, 85%, 35%),
-  &#39;light-gray&#39;: &#39;brand-blue&#39; (&#39;tint&#39;: 80%, get-function(&#39;desaturate&#39;): 80%),
+  &#39;light-gray&#39;: &#39;brand-blue&#39; (&#39;tint&#39;: 80%, &#39;desaturate&#39;: 80%),
 );
 @include herman-add(&#39;colors&#39;, &#39;brand-colors&#39;, $brand-colors, get-function(&#39;color&#39;));
 /* #{$herman} */</code></pre>
@@ -1985,7 +1985,7 @@ and converted to json-ready<span class="widont">&nbsp;</span>strings</p>
       <pre class="hljs-pre"><code class="lang-scss">$brand-colors: (
   &#39;brand-orange&#39;: hsl(24, 100%, 39%),
   &#39;brand-blue&#39;: hsl(195, 85%, 35%),
-  &#39;light-gray&#39;: &#39;brand-blue&#39; (&#39;tint&#39;: 80%, get-function(&#39;desaturate&#39;): 80%),
+  &#39;light-gray&#39;: &#39;brand-blue&#39; (&#39;tint&#39;: 80%, &#39;desaturate&#39;: 80%),
 );
 /* #{herman-map-compile($brand-colors, get-function(&#39;color&#39;))} */</code></pre>
     </div>

--- a/docs/config-colors.html
+++ b/docs/config-colors.html
@@ -771,9 +771,9 @@ followed by an optional map of adjustments
       
       
       <pre class="hljs-pre"><code class="lang-scss">$neutral-colors: (
-  &#39;light-gray&#39;: &#39;brand-blue&#39; (&#39;tint&#39;: 80%, get-function(&#39;desaturate&#39;): 80%),
-  &#39;gray&#39;: &#39;brand-blue&#39; (get-function(&#39;desaturate&#39;): 80%),
-  &#39;black&#39;: &#39;brand-blue&#39; (&#39;shade&#39;: 30%, get-function(&#39;desaturate&#39;): 80%)
+  &#39;light-gray&#39;: &#39;brand-blue&#39; (&#39;tint&#39;: 80%, &#39;desaturate&#39;: 80%),
+  &#39;gray&#39;: &#39;brand-blue&#39; (&#39;desaturate&#39;: 80%),
+  &#39;black&#39;: &#39;brand-blue&#39; (&#39;shade&#39;: 30%, &#39;desaturate&#39;: 80%)
 );</code></pre>
     </div>
   
@@ -1017,11 +1017,11 @@ before they are used in styling patterns and<span class="widont">&nbsp;</span>co
   &#39;underline&#39;: &#39;action&#39; (&#39;tint&#39;: 75%),
   &#39;border&#39;: &#39;gray&#39;,
   &#39;border-light&#39;: &#39;light-gray&#39;,
-  &#39;shadow&#39;: &#39;gray&#39; (get-function(&#39;rgba&#39;): 0.5),
+  &#39;shadow&#39;: &#39;gray&#39; (&#39;rgba&#39;: 0.5),
   &#39;callout&#39;: &#39;theme-light&#39;,
   &#39;slight&#39;: &#39;callout&#39; (&#39;tint&#39;: 90%),
   &#39;code&#39;: &#39;theme-dark&#39;,
-  &#39;code-shadow&#39;: &#39;code&#39; (get-function(&#39;rgba&#39;): 0.2)
+  &#39;code-shadow&#39;: &#39;code&#39; (&#39;rgba&#39;: 0.2)
 );</code></pre>
     </div>
   

--- a/docs/config-utils.html
+++ b/docs/config-utils.html
@@ -381,6 +381,257 @@
 
 
 
+<section class="item" id="variable--functions">
+  
+    
+  
+  
+
+  
+  
+  
+  
+
+  <div data-item-section="header">
+    <h2 class="item-title">
+      
+        <span class="item-type"></span>
+      
+
+      
+        <a href="#variable--functions" class="item-name">$functions</a>
+      
+
+      
+        <span class="value-type">(map)</span>
+      
+
+      
+    </h2>
+
+    
+  
+
+
+    
+    
+    
+  
+    <div class="code-block">
+      
+        <div class="code-header">
+          <span class="code-language">
+            scss
+          </span>
+
+          
+        </div>
+      
+
+      
+      
+      <pre class="hljs-pre"><code class="lang-scss">$functions: (
+  &#39;darken&#39;: get-function(&#39;darken&#39;),
+  &#39;desaturate&#39;: get-function(&#39;desaturate&#39;),
+  &#39;rgba&#39;: get-function(&#39;rgba&#39;),
+  &#39;convert&#39;: &#39;convert-units&#39;
+);</code></pre>
+    </div>
+  
+
+    
+  
+  
+  
+  
+
+  
+    <div class="text-block">
+      <p>These functions will be made available to
+accoutrement-color &amp; accoutrement-scale tools,
+for use in the <code>$colors</code> and <code>$sizes</code> configuration maps.
+Register additional functions as needed,
+or establish alias names for existing<span class="widont">&nbsp;</span>functions.</p>
+
+      
+  
+
+      
+  
+
+      
+  
+
+    </div>
+  
+
+  </div>
+
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    
+  <div data-item-section="property">
+    
+      <h3 class="item-subtitle">
+        <span class="item-subtitle-main">Map Properties</span>
+        
+      </h3>
+    
+
+    
+      
+        
+  
+  
+
+  
+  <div class="param-list">
+    <h4 class="param-title">
+      
+      
+        <span class="item-name">&lt;alias&gt;:</span>
+      
+      
+      <span class="value-type">(function |<span class="widont">&nbsp;</span>string)</span>
+      
+    </h4>
+
+    
+      
+      <div class="param-details text-block">
+        <p>Use <code>get-function()</code> to capture a first-class function,
+or use a string to reference existing functions and<span class="widont">&nbsp;</span>alias-keys</p>
+
+      </div>
+    
+  </div>
+
+
+      
+
+      
+  
+
+      
+  
+
+      
+  
+
+      
+  
+
+    
+  </div>
+
+  
+
+
+  
+  
+
+
+  
+
+    
+  <div data-item-section="related">
+    
+      <h3 class="item-subtitle">
+        <span class="item-subtitle-main">Related</span>
+        
+      </h3>
+    
+
+    
+      
+        
+  
+
+  
+  <div class="param-list">
+    <h4 class="param-title">
+      
+      
+        <a href="http://oddbird.net/accoutrement-color" class="item-name">Accoutrement-Color</a>
+      
+      
+      
+      <span class="item-note">[external]</span>
+    </h4>
+
+    
+  </div>
+
+
+      
+        
+  
+
+  
+  <div class="param-list">
+    <h4 class="param-title">
+      
+      
+        <a href="http://oddbird.net/accoutrement-scale" class="item-name">Accoutrement-Scale</a>
+      
+      
+      
+      <span class="item-note">[external]</span>
+    </h4>
+
+    
+  </div>
+
+
+      
+
+      
+    
+  </div>
+
+  
+  
+  
+  
+    
+    
+  
+
+  
+
+  
+  
+
+
+  
+  
+
+  
+  
+
+</section>
+
+  
+    
+    
+
+
+
+
+
+
+
+
+
+
 <section class="item" id="mixin--config">
   
     

--- a/docs/demo_colors.html
+++ b/docs/demo_colors.html
@@ -832,9 +832,9 @@ where the values need to be parsed and compiled
 before they can be exported to Herman.
 Using <a href="http://oddbird.net/accoutrement-color">accoutrement-color</a>, our maps look like<span class="widont">&nbsp;</span>this:</p>
 <pre><code class="lang-scss">$demo-noncolors: (
-  'light-gray': 'brand-blue' ('tint': 80%, get-function('desaturate'): 80%),
-  'gray': 'brand-blue' (get-function('desaturate'): 80%),
-  'black': 'brand-blue' ('shade': 30%, get-function('desaturate'): 80%),
+  'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
+  'gray': 'brand-blue' ('desaturate': 80%),
+  'black': 'brand-blue' ('shade': 30%, 'desaturate': 80%),
 );
 </code></pre>
 <p>Our <code>color()</code> function knows how to interpret that syntax
@@ -916,9 +916,9 @@ along with any additional arguments required for that<span class="widont">&nbsp;
       
       <pre class="hljs-pre"><code class="lang-scss">$herman: ();
 $demo-noncolors: (
-  &#39;light-gray&#39;: &#39;brand-blue&#39; (&#39;tint&#39;: 80%, get-function(&#39;desaturate&#39;): 80%),
-  &#39;gray&#39;: &#39;brand-blue&#39; (get-function(&#39;desaturate&#39;): 80%),
-  &#39;black&#39;: &#39;brand-blue&#39; (&#39;shade&#39;: 30%, get-function(&#39;desaturate&#39;): 80%),
+  &#39;light-gray&#39;: &#39;brand-blue&#39; (&#39;tint&#39;: 80%, &#39;desaturate&#39;: 80%),
+  &#39;gray&#39;: &#39;brand-blue&#39; (&#39;desaturate&#39;: 80%),
+  &#39;black&#39;: &#39;brand-blue&#39; (&#39;shade&#39;: 30%, &#39;desaturate&#39;: 80%),
 );
 
 @include herman-add(

--- a/docs/demo_examples.html
+++ b/docs/demo_examples.html
@@ -468,6 +468,8 @@ with an API for supporting additional<span class="widont">&nbsp;</span>languages
 <p>Example annotations with language set to <code>sass</code> or <code>scss</code>
 will be compiled by Herman,
 and display the output along with the<span class="widont">&nbsp;</span>source.</p>
+<p>Note that Sass/Scss examples require <code>node-sass</code>
+to be installed, if it isn’t already: <code>npm install node-sass</code>.</p>
 <p>All Sass examples must be complete and valid,
 with the ability to import Sass partials inside each example.
 In order for this to work with Sass/Scss,

--- a/docs/index.html
+++ b/docs/index.html
@@ -337,8 +337,14 @@ and<span class="widont">&nbsp;</span>more.</p>
 <h2 id="getting-started">Getting Started</h2>
 <pre><code class="lang-bash">npm install sassdoc sassdoc-theme-herman
 </code></pre>
+<p>Note: If you plan to use Herman to display samples of Sass/Scss code,
+<code>node-sass</code> is required as a <code>peerDependency</code>.
+If it’s not already installed in your project,
+install it with<span class="widont">&nbsp;</span>Herman:</p>
+<pre><code class="lang-bash">npm install node-sass
+</code></pre>
 <p>See the <a href="http://sassdoc.com/getting-started/">SassDoc documentation</a>
-to install SassDoc and run it via various build tools.
+to run SassDoc via various build tools.
 Specify <code>herman</code> as the theme
 in your SassDoc<span class="widont">&nbsp;</span>options:</p>
 <pre><code class="lang-bash">sassdoc &lt;src&gt; --theme herman

--- a/lib/annotations/example.js
+++ b/lib/annotations/example.js
@@ -3,13 +3,11 @@
 const beautify = require('html').prettyPrint;
 const path = require('path');
 const Promise = require('bluebird');
-const sass = require('node-sass');
 const stripIndent = require('strip-indent');
 
 const getNunjucksEnv = require('../utils/getNunjucksEnv');
 const renderIframe = require('../renderIframe');
 
-const renderSass = Promise.promisify(sass.render);
 const beautifyOpts = {
   indent_size: 2,
   max_char: 0,
@@ -27,6 +25,7 @@ module.exports = env => {
   const baseExampleFn = require('sassdoc/dist/annotation/annotations/example')
     .default;
   const baseExample = baseExampleFn();
+  let renderSass;
   return {
     name: 'example',
     parse: baseExample.parse,
@@ -59,6 +58,18 @@ module.exports = env => {
             ).trim();
           } else if (exampleItem.type === 'scss') {
             exampleItem.rendered = undefined;
+            if (!renderSass) {
+              try {
+                // eslint-disable-next-line global-require
+                renderSass = Promise.promisify(require('node-sass').render);
+              } catch (err) {
+                env.logger.warn(
+                  'Cannot find `node-sass` module, which is required ' +
+                    'when using `@example scss` annotation.'
+                );
+                return;
+              }
+            }
             let sassData = exampleItem.code;
             let includepaths = [];
             let outputStyle = 'expanded';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "lunr": "^2.1.6",
     "markdown-it": "^8.4.1",
     "markdown-it-named-headers": "^0.0.4",
-    "node-sass": "^4.8.3",
     "nunjucks": "^2.5.2",
     "sassdoc-extras": "^2.4.1",
     "strip-indent": "^2.0.0",
@@ -32,16 +31,17 @@
     "vinyl-fs": "^3.0.0"
   },
   "peerDependencies": {
+    "node-sass": "^4.0.0",
     "sassdoc": "^2.5.0"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0-beta.43",
-    "@babel/polyfill": "7.0.0-beta.43",
-    "@babel/preset-env": "7.0.0-beta.43",
-    "accoutrement-color": "^2.2.3",
+    "@babel/core": "7.0.0-beta.44",
+    "@babel/polyfill": "7.0.0-beta.44",
+    "@babel/preset-env": "7.0.0-beta.44",
+    "accoutrement-color": "^2.3.0",
     "accoutrement-init": "^1.1.2",
     "accoutrement-layout": "^3.0.2",
-    "accoutrement-scale": "^5.0.1",
+    "accoutrement-scale": "^6.0.0",
     "accoutrement-type": "^4.0.2",
     "autoprefixer": "^8.2.0",
     "babel-eslint": "^8.2.2",
@@ -80,11 +80,12 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "4.0.0-beta.0",
-    "lint-staged": "^7.0.2",
+    "lint-staged": "^7.0.3",
     "lodash.set": "^4.3.2",
     "mark.js": "^8.11.0",
     "matchmedia-polyfill": "^0.3.0",
     "mocha": "^5.0.5",
+    "node-sass": "^4.8.3",
     "nyc": "^11.6.0",
     "plugin-error": "^1.0.0",
     "postcss-loader": "^2.1.3",
@@ -95,7 +96,7 @@
     "sinon": "^4.5.0",
     "sinon-chai": "^3.0.0",
     "srcdoc-polyfill": "^1.0.0",
-    "webpack": "^4.4.1",
+    "webpack": "^4.5.0",
     "webpack-cli": "^2.0.13"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "7.0.0-beta.44",
     "@babel/polyfill": "7.0.0-beta.44",
     "@babel/preset-env": "7.0.0-beta.44",
-    "accoutrement-color": "^2.3.0",
+    "accoutrement-color": "^2.3.1",
     "accoutrement-init": "^1.1.2",
     "accoutrement-layout": "^3.0.2",
     "accoutrement-scale": "^6.0.0",

--- a/scss/config/_abstracts.scss
+++ b/scss/config/_abstracts.scss
@@ -4,6 +4,15 @@
 /// # Herman Config: Private Helpers
 /// @group config-utils
 
+// Functions
+// ---------
+$functions: (
+  'darken': get-function('darken'),
+  'desaturate': get-function('desaturate'),
+  'rgba': get-function('rgba'),
+  'convert': get-function('convert-units')
+);
+
 // Config
 // ------
 /// Internal utility for managing Herman and Accoutrement maps

--- a/scss/config/_abstracts.scss
+++ b/scss/config/_abstracts.scss
@@ -6,6 +6,21 @@
 
 // Functions
 // ---------
+/// These functions will be made available to
+/// accoutrement-color & accoutrement-scale tools,
+/// for use in the `$colors` and `$sizes` configuration maps.
+/// Register additional functions as needed,
+/// or establish alias names for existing functions.
+///
+/// @group config-utils
+/// @type map
+///
+/// @link http://oddbird.net/accoutrement-color Accoutrement-Color
+/// @link http://oddbird.net/accoutrement-scale Accoutrement-Scale
+///
+/// @prop {function | string} <alias> -
+///   Use `get-function()` to capture a first-class function,
+///   or use a string to reference existing functions and alias-keys
 $functions: (
   'darken': get-function('darken'),
   'desaturate': get-function('desaturate'),

--- a/scss/config/_abstracts.scss
+++ b/scss/config/_abstracts.scss
@@ -10,7 +10,7 @@ $functions: (
   'darken': get-function('darken'),
   'desaturate': get-function('desaturate'),
   'rgba': get-function('rgba'),
-  'convert': get-function('convert-units')
+  'convert': 'convert-units'
 );
 
 // Config

--- a/scss/config/_colors.scss
+++ b/scss/config/_colors.scss
@@ -54,9 +54,9 @@ $brand-colors: (
 /// @colors
 /// @group config-colors
 $neutral-colors: (
-  'light-gray': 'brand-blue' ('tint': 80%, get-function('desaturate'): 80%),
-  'gray': 'brand-blue' (get-function('desaturate'): 80%),
-  'black': 'brand-blue' ('shade': 30%, get-function('desaturate'): 80%)
+  'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
+  'gray': 'brand-blue' ('desaturate': 80%),
+  'black': 'brand-blue' ('shade': 30%, 'desaturate': 80%)
 );
 
 @include config('colors', 'neutral-colors', $neutral-colors);
@@ -83,11 +83,11 @@ $theme-colors: (
   'underline': 'action' ('tint': 75%),
   'border': 'gray',
   'border-light': 'light-gray',
-  'shadow': 'gray' (get-function('rgba'): 0.5),
+  'shadow': 'gray' ('rgba': 0.5),
   'callout': 'theme-light',
   'slight': 'callout' ('tint': 90%),
   'code': 'theme-dark',
-  'code-shadow': 'code' (get-function('rgba'): 0.2)
+  'code-shadow': 'code' ('rgba': 0.2)
 );
 
 @include config('colors', 'theme-colors', $theme-colors);

--- a/scss/previews/_size.scss
+++ b/scss/previews/_size.scss
@@ -107,13 +107,13 @@
     ),
     linear-gradient(
       to left,
-      color('border-light' (get-function('rgba'): 0.5)) 1px,
+      color('border-light' ('rgba': 0.5)) 1px,
       transparent 1px,
       transparent
     ),
     linear-gradient(
       to left,
-      color('border-light' (get-function('rgba'): 0.25)) 1px,
+      color('border-light' ('rgba': 0.25)) 1px,
       transparent 1px,
       transparent
     );

--- a/scss/samples/_colors.scss
+++ b/scss/samples/_colors.scss
@@ -142,9 +142,9 @@ $demo-colors: (
 @include herman-add('colors', 'demo-colors', $demo-colors);
 
 $demo-noncolors: (
-  'light-gray': 'brand-blue' ('tint': 80%, get-function('desaturate'): 80%),
-  'gray': 'brand-blue' (get-function('desaturate'): 80%),
-  'black': 'brand-blue' ('shade': 30%, get-function('desaturate'): 80%)
+  'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
+  'gray': 'brand-blue' ('desaturate': 80%),
+  'black': 'brand-blue' ('shade': 30%, 'desaturate': 80%)
 );
 
 /// ## Compile and export complex maps
@@ -158,9 +158,9 @@ $demo-noncolors: (
 ///
 /// ```scss
 /// $demo-noncolors: (
-///   'light-gray': 'brand-blue' ('tint': 80%, get-function('desaturate'): 80%),
-///   'gray': 'brand-blue' (get-function('desaturate'): 80%),
-///   'black': 'brand-blue' ('shade': 30%, get-function('desaturate'): 80%),
+///   'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
+///   'gray': 'brand-blue' ('desaturate': 80%),
+///   'black': 'brand-blue' ('shade': 30%, 'desaturate': 80%),
 /// );
 /// ```
 ///
@@ -179,9 +179,9 @@ $demo-noncolors: (
 /// @example scss
 ///   $herman: ();
 ///   $demo-noncolors: (
-///     'light-gray': 'brand-blue' ('tint': 80%, get-function('desaturate'): 80%),
-///     'gray': 'brand-blue' (get-function('desaturate'): 80%),
-///     'black': 'brand-blue' ('shade': 30%, get-function('desaturate'): 80%),
+///     'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
+///     'gray': 'brand-blue' ('desaturate': 80%),
+///     'black': 'brand-blue' ('shade': 30%, 'desaturate': 80%),
 ///   );
 ///
 ///   @include herman-add(

--- a/scss/samples/_examples.scss
+++ b/scss/samples/_examples.scss
@@ -56,6 +56,9 @@
 /// will be compiled by Herman,
 /// and display the output along with the source.
 ///
+/// Note that Sass/Scss examples require `node-sass`
+/// to be installed, if it isn't already: `npm install node-sass`.
+///
 /// All Sass examples must be complete and valid,
 /// with the ability to import Sass partials inside each example.
 /// In order for this to work with Sass/Scss,

--- a/scss/utilities/_maps.scss
+++ b/scss/utilities/_maps.scss
@@ -28,7 +28,7 @@
 /// @example scss
 ///   $brand-colors: (
 ///     'brand-blue': hsl(195, 85%, 35%),
-///     'light-gray': 'brand-blue' ('tint': 80%, get-function('desaturate'): 80%),
+///     'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
 ///   );
 ///   @include herman-add('colors', 'brand-colors', $brand-colors, get-function('color'));
 ///   /* #{$herman} */
@@ -76,7 +76,7 @@
 ///   $brand-colors: (
 ///     'brand-orange': hsl(24, 100%, 39%),
 ///     'brand-blue': hsl(195, 85%, 35%),
-///     'light-gray': 'brand-blue' ('tint': 80%, get-function('desaturate'): 80%),
+///     'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
 ///   );
 ///   /* #{herman-map-compile($brand-colors, get-function('color'))} */
 @function herman-map-compile($map, $function, $args...) {

--- a/test/sass/utilities/_maps.scss
+++ b/test/sass/utilities/_maps.scss
@@ -3,9 +3,9 @@
 
 $colors-initial: (
   'brand-blue': hsl(195, 85%, 35%),
-  'light-gray': 'brand-blue' ('tint': 80%, get-function('desaturate'): 80%),
-  'gray': 'brand-blue' (get-function('desaturate'): 80%),
-  'black': 'brand-blue' ('shade': 30%, get-function('desaturate'): 80%)
+  'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
+  'gray': 'brand-blue' ('desaturate': 80%),
+  'black': 'brand-blue' ('shade': 30%, 'desaturate': 80%)
 );
 
 $colors-compiled: (
@@ -24,7 +24,7 @@ $darken: (
 
 $sizes: (
   'root': 20px,
-  'rhythm': 'root' ('fifth': 1, get-function('convert-units'): 'rem')
+  'rhythm': 'root' ('fifth': 1, 'convert': 'rem')
 );
 
 $sizes-compiled: (
@@ -45,7 +45,7 @@ $sizes-compiled: (
 
   @include it('allows extra args be passed in') {
     @include assert-equal(
-      herman-map-compile($colors-compiled, get-function('darken'), 20%),
+      herman-map-compile($colors-compiled, 'darken', 20%),
       $darken,
       $inspect: true
     );
@@ -81,13 +81,7 @@ $sizes-compiled: (
 
     @include assert-equal($herman, $empty);
 
-    @include herman-add(
-      'colors',
-      'dark',
-      $colors-compiled,
-      get-function('darken'),
-      20%
-    );
+    @include herman-add('colors', 'dark', $colors-compiled, 'darken', 20%);
     $expect: ('colors': ('dark': $darken));
 
     @include assert-equal($herman, $expect, $inspect: true);

--- a/test/sass/utilities/_maps.scss
+++ b/test/sass/utilities/_maps.scss
@@ -45,7 +45,7 @@ $sizes-compiled: (
 
   @include it('allows extra args be passed in') {
     @include assert-equal(
-      herman-map-compile($colors-compiled, 'darken', 20%),
+      herman-map-compile($colors-compiled, get-function('darken'), 20%),
       $darken,
       $inspect: true
     );
@@ -81,7 +81,13 @@ $sizes-compiled: (
 
     @include assert-equal($herman, $empty);
 
-    @include herman-add('colors', 'dark', $colors-compiled, 'darken', 20%);
+    @include herman-add(
+      'colors',
+      'dark',
+      $colors-compiled,
+      get-function('darken'),
+      20%
+    );
     $expect: ('colors': ('dark': $darken));
 
     @include assert-equal($herman, $expect, $inspect: true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,23 +2,23 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.43", "@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.0.0-beta.40":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.43.tgz#57281887da181b4f9a3e72151f54f3237bf011eb"
+"@babel/code-frame@7.0.0-beta.44", "@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.0.0-beta.40":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.43"
+    "@babel/highlight" "7.0.0-beta.44"
 
-"@babel/core@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.43.tgz#2e5d50b338b1484f4de7a92047e65b88f3fd2eed"
+"@babel/core@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.44.tgz#90bb9e897427e7ebec2a1b857f458ff74ca28057"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.43"
-    "@babel/generator" "7.0.0-beta.43"
-    "@babel/helpers" "7.0.0-beta.43"
-    "@babel/template" "7.0.0-beta.43"
-    "@babel/traverse" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
-    babylon "7.0.0-beta.43"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/generator" "7.0.0-beta.44"
+    "@babel/helpers" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     convert-source-map "^1.1.0"
     debug "^3.1.0"
     json5 "^0.5.0"
@@ -28,478 +28,478 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.43.tgz#9f32baf9fe6a4a79872d1825bb7541ed992573ca"
+"@babel/generator@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
   dependencies:
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/types" "7.0.0-beta.44"
     jsesc "^2.5.1"
     lodash "^4.2.0"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/helper-annotate-as-pure@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.43.tgz#7bf40e89ea38f8657aa24116f5ed7d62ca4b7b49"
+"@babel/helper-annotate-as-pure@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.44.tgz#8ecf33cc5235295afcc7f160a63cab17ce7776f4"
   dependencies:
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-builder-binary-assignment-operator-visitor@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.43.tgz#88975b2aff0c02058ff54616d9768c82d50397e5"
+"@babel/helper-builder-binary-assignment-operator-visitor@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.44.tgz#0e86d393c192bc846f871f3fcf4920b08a9cbb27"
   dependencies:
-    "@babel/helper-explode-assignable-expression" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/helper-explode-assignable-expression" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-call-delegate@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.43.tgz#f4d71a3ace2a452c3ad423697541ef17cd2bf29b"
+"@babel/helper-call-delegate@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.44.tgz#e644536f8b3d2eabeecca000037cdced8e453d26"
   dependencies:
-    "@babel/helper-hoist-variables" "7.0.0-beta.43"
-    "@babel/traverse" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/helper-hoist-variables" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-define-map@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.43.tgz#4fcef873cd67afe56d943e4e36d78d32711166dc"
+"@babel/helper-define-map@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.44.tgz#d63578a67c9654ff9f32e55bbf269c2d5f094c97"
   dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/helper-function-name" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/helper-explode-assignable-expression@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.43.tgz#0e9dac5fe1a9c9d3537b0f2695ecbe1b8e121837"
+"@babel/helper-explode-assignable-expression@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.44.tgz#1f06b9f76017deac2767ee09f3021d5b209bf5cd"
   dependencies:
-    "@babel/traverse" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-function-name@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.43.tgz#c1f521f0782a0e544fdfae2d88b6a2895a38a498"
+"@babel/helper-function-name@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz#e18552aaae2231100a6e485e03854bc3532d44dd"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.43"
-    "@babel/template" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/helper-get-function-arity" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-get-function-arity@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.43.tgz#c00072b6d290ce037dc9037fe99037c7686a56e3"
+"@babel/helper-get-function-arity@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz#d03ca6dd2b9f7b0b1e6b32c56c72836140db3a15"
   dependencies:
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-hoist-variables@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.43.tgz#dd26b084289590f070d0060c91ad802ad9756063"
+"@babel/helper-hoist-variables@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.44.tgz#a1bbb2c25f9b4058e041ecc1556f096eacdbd142"
   dependencies:
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-module-imports@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.43.tgz#fdb439d52757c2466de3c39943a2aabc06a70956"
+"@babel/helper-module-imports@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.44.tgz#60edc68cdf17e13eaca5be813c96127303085133"
   dependencies:
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/types" "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/helper-module-transforms@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.43.tgz#b2ddc025124550605beb39e67fffce80300b48db"
+"@babel/helper-module-transforms@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.44.tgz#185dc17b37c4b9cc3daee0f0f44e74f000e21bb7"
   dependencies:
-    "@babel/helper-module-imports" "7.0.0-beta.43"
-    "@babel/helper-simple-access" "7.0.0-beta.43"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.43"
-    "@babel/template" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/helper-module-imports" "7.0.0-beta.44"
+    "@babel/helper-simple-access" "7.0.0-beta.44"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/helper-optimise-call-expression@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.43.tgz#046a3c719e392ac12fae1b89001757c2578509f8"
+"@babel/helper-optimise-call-expression@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.44.tgz#84ceabfb99afc1c185d15668114a697cdad7a5d0"
   dependencies:
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-plugin-utils@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.43.tgz#a5c95110e9bf53b96b339661c96c37efd0960568"
+"@babel/helper-plugin-utils@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.44.tgz#9f590bc3ae6daa8a10b853233baa3e25d263751d"
 
-"@babel/helper-regex@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0-beta.43.tgz#8ff44801e80f677524c25d1897ac6470d01369f4"
+"@babel/helper-regex@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0-beta.44.tgz#f5b6828c1e40f0b74ab6ed90abdd52be0c38a74e"
   dependencies:
     lodash "^4.2.0"
 
-"@babel/helper-remap-async-to-generator@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.43.tgz#a03ada2c7543a1c8a890321c3db8ab9a0f07347e"
+"@babel/helper-remap-async-to-generator@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.44.tgz#8ad8c12a57444042ca281bdb16734841425938ad"
   dependencies:
-    "@babel/helper-annotate-as-pure" "7.0.0-beta.43"
-    "@babel/helper-wrap-function" "7.0.0-beta.43"
-    "@babel/template" "7.0.0-beta.43"
-    "@babel/traverse" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/helper-annotate-as-pure" "7.0.0-beta.44"
+    "@babel/helper-wrap-function" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-replace-supers@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.43.tgz#f2ddd601c9e478398aa690b2881058c417ef0be3"
+"@babel/helper-replace-supers@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.44.tgz#cf18697951431f533f9d8c201390b158d4a3ee04"
   dependencies:
-    "@babel/helper-optimise-call-expression" "7.0.0-beta.43"
-    "@babel/template" "7.0.0-beta.43"
-    "@babel/traverse" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/helper-optimise-call-expression" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-simple-access@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.43.tgz#b8e869f5a4cf1e88a5c11b9e32998d5045d89cc7"
+"@babel/helper-simple-access@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.44.tgz#03fb6bfc91eb0a95f6c11499153f8c663654dce5"
   dependencies:
-    "@babel/template" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/helper-split-export-declaration@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.43.tgz#1e95b16ce597df81ce1face60f5ea89a4631a7bf"
+"@babel/helper-split-export-declaration@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
   dependencies:
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helper-wrap-function@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.43.tgz#37aa889550144ea7b7f5dbdc4a74c843bb06069a"
+"@babel/helper-wrap-function@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.44.tgz#d128718a543f313264dff7cb386957e3e465c95d"
   dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.43"
-    "@babel/template" "7.0.0-beta.43"
-    "@babel/traverse" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/helper-function-name" "7.0.0-beta.44"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/helpers@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.43.tgz#a45078bdd135012229c3bb209c86ef1f953ba041"
+"@babel/helpers@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.44.tgz#b1cc87fdc3b77351c0a4860bcd9d4ef457919bfd"
   dependencies:
-    "@babel/template" "7.0.0-beta.43"
-    "@babel/traverse" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
+    "@babel/template" "7.0.0-beta.44"
+    "@babel/traverse" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
 
-"@babel/highlight@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.43.tgz#7bd0415ca160495a22b3a234f0841b4a9ab0de26"
+"@babel/highlight@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.43.tgz#05bf2d6a8c65f3820be38fb0e152a4b405860a6a"
+"@babel/plugin-proposal-async-generator-functions@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.44.tgz#b08d90cd0f6a82e11cb5ae64eee4fba7d0d7999e"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-remap-async-to-generator" "7.0.0-beta.43"
-    "@babel/plugin-syntax-async-generators" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-remap-async-to-generator" "7.0.0-beta.44"
+    "@babel/plugin-syntax-async-generators" "7.0.0-beta.44"
 
-"@babel/plugin-proposal-object-rest-spread@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.43.tgz#b6119c5692df571626a1f8e5c7276b1f2b3d79e9"
+"@babel/plugin-proposal-object-rest-spread@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.44.tgz#b7817770cb9cf72f2e73ca6fcb83d61a87305259"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.44"
 
-"@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.43.tgz#d8dae05a573e2e0419dc6a6b89ad301e53754cc0"
+"@babel/plugin-proposal-optional-catch-binding@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0-beta.44.tgz#87928d30c9fab4803cdba29f9c1260c16bc5d30f"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.44"
 
-"@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.43.tgz#2c37c0358acf38b8886db7a4f71ae20a258e2a43"
+"@babel/plugin-proposal-unicode-property-regex@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0-beta.44.tgz#5efb0ddbe6635b4cb6674e961a16c28cef3cdb7f"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-regex" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-regex" "7.0.0-beta.44"
     regexpu-core "^4.1.3"
 
-"@babel/plugin-syntax-async-generators@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.43.tgz#43e0893f58bdb834c4c00504e1992926d38d660b"
+"@babel/plugin-syntax-async-generators@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.44.tgz#5cf7ec4256ddd7df62654171059188bee2b3addc"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.43.tgz#af76c48e092b68c53d065c35fbad7f5f53e76229"
+"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.44.tgz#c37d271e4edf8a1b5d4623fb2917ba0f5a9da3b3"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-syntax-optional-catch-binding@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.43.tgz#486aa07340457956f7a4d351608a447b3f5b1174"
+"@babel/plugin-syntax-optional-catch-binding@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0-beta.44.tgz#c79ee93c371831b104bb0a1cc9c85ac5373af4f3"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-arrow-functions@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.43.tgz#5a4cd89f16a30c92f9ed8c2c095f402ff5bdd2a8"
+"@babel/plugin-transform-arrow-functions@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.44.tgz#718dae35046eca6938c731d1eae10c5471c17398"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-async-to-generator@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.43.tgz#85214c9e0a9f7d43ea148ea3867975ffe01c48ca"
+"@babel/plugin-transform-async-to-generator@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.44.tgz#b91881aa6e1a6bd330be31df43a936feeb145c29"
   dependencies:
-    "@babel/helper-module-imports" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-remap-async-to-generator" "7.0.0-beta.43"
+    "@babel/helper-module-imports" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-remap-async-to-generator" "7.0.0-beta.44"
 
-"@babel/plugin-transform-block-scoped-functions@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.43.tgz#fa90000c96cc9e09f16fcaf924a552bb693886c5"
+"@babel/plugin-transform-block-scoped-functions@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.44.tgz#d31bb2231ae861fa4ea6f9974b8b8f5641a3460a"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-block-scoping@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.43.tgz#35d7ffb0f70e215fc7e237a7c477255f859832b1"
+"@babel/plugin-transform-block-scoping@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.44.tgz#a7b640e112743634b9226996e58ab92cdebb4ff0"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/plugin-transform-classes@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.43.tgz#9c367f9b6cd8fb0453dd19a556fa4ff6c2ddcf57"
+"@babel/plugin-transform-classes@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.44.tgz#5410fcf6a9eeba3cc8e25bf0f72b43358336b534"
   dependencies:
-    "@babel/helper-annotate-as-pure" "7.0.0-beta.43"
-    "@babel/helper-define-map" "7.0.0-beta.43"
-    "@babel/helper-function-name" "7.0.0-beta.43"
-    "@babel/helper-optimise-call-expression" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-replace-supers" "7.0.0-beta.43"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.43"
+    "@babel/helper-annotate-as-pure" "7.0.0-beta.44"
+    "@babel/helper-define-map" "7.0.0-beta.44"
+    "@babel/helper-function-name" "7.0.0-beta.44"
+    "@babel/helper-optimise-call-expression" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-replace-supers" "7.0.0-beta.44"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.44"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.43.tgz#32a623641f9de6c43bc60bb775f7115b5d9325fc"
+"@babel/plugin-transform-computed-properties@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.44.tgz#1421b4e1a18dc3bd276d8648a12a4f8ea088c6a1"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-destructuring@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.43.tgz#7e45d4162834d3a8c000dfad8d368490bcd81d2f"
+"@babel/plugin-transform-destructuring@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.44.tgz#57c8b40d56db45eaa39b44696818b24004306752"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-dotall-regex@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.43.tgz#f4c69c5cb09f6e7a6f2bb5441eafaab5b0232c19"
+"@babel/plugin-transform-dotall-regex@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0-beta.44.tgz#414bd71f39199e45a8ddaa8053cb5bd9690707f4"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-regex" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-regex" "7.0.0-beta.44"
     regexpu-core "^4.1.3"
 
-"@babel/plugin-transform-duplicate-keys@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.43.tgz#f0766c4d4bbd706df45112373ec618349b449582"
+"@babel/plugin-transform-duplicate-keys@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.44.tgz#e945a7990d9adca4f9b58a7af46cdb1515b925b1"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-exponentiation-operator@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.43.tgz#52f1710bcb61c6fffa82b8c9ddb06604f6bad8b8"
+"@babel/plugin-transform-exponentiation-operator@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.44.tgz#e6a9699b5036a7a75274e1546c23414ba945a135"
   dependencies:
-    "@babel/helper-builder-binary-assignment-operator-visitor" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-builder-binary-assignment-operator-visitor" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-for-of@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.43.tgz#f309f82b4ab3f2de44c119ce28fd0535cab31623"
+"@babel/plugin-transform-for-of@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.44.tgz#b157e38e74c07beacbac01c1946b8ad11dbea32c"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-function-name@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.43.tgz#beccd356d18654e2798c2b4a39f75fbf2470c0fe"
+"@babel/plugin-transform-function-name@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.44.tgz#8cd5986dac8a0fd0df21b79e9a20de9b2c37b4c4"
   dependencies:
-    "@babel/helper-function-name" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-function-name" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-literals@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.43.tgz#45c33a38d71b4eb8400fafbe16cafa0c5da508b5"
+"@babel/plugin-transform-literals@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.44.tgz#8c85631ea6fd8a6eecefdb81177ed6ae3d34b195"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-modules-amd@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.43.tgz#2b41f9bb758d2bd852f50446ecfaec9d04b986ad"
+"@babel/plugin-transform-modules-amd@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.44.tgz#4d2df3f507f00bbbea3bc3ee07505ed97df1f22e"
   dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-module-transforms" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-modules-commonjs@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.43.tgz#5f98aa9da258acfe3116e27749fbdb340308699d"
+"@babel/plugin-transform-modules-commonjs@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.44.tgz#864a1fef64091bd5241b0aa7d4b235fb29f60580"
   dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-simple-access" "7.0.0-beta.43"
+    "@babel/helper-module-transforms" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-simple-access" "7.0.0-beta.44"
 
-"@babel/plugin-transform-modules-systemjs@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.43.tgz#58f5f7f126f1ea48996e7ae7236eb98bf970daca"
+"@babel/plugin-transform-modules-systemjs@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.44.tgz#f27e97e592dd9739c8c5df478f1729bb4b63b386"
   dependencies:
-    "@babel/helper-hoist-variables" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-hoist-variables" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-modules-umd@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.43.tgz#4b7995cd7910b28235bb9b00209369faa7f6387e"
+"@babel/plugin-transform-modules-umd@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.44.tgz#66ca82476b72bfd1ce2d410ceaf2e85c1639a616"
   dependencies:
-    "@babel/helper-module-transforms" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-module-transforms" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-new-target@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.43.tgz#c59818b73616d7a51670c5e798ae263a5fccfb30"
+"@babel/plugin-transform-new-target@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0-beta.44.tgz#7f3a2c46e01b5433093430892fbce287583cb1b8"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-object-super@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.43.tgz#19843f6a004f4482f183c39c3efe1e9388c9f4fb"
+"@babel/plugin-transform-object-super@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.44.tgz#3c1688a7b38c4de8af269ff5c618cfd602864a39"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-replace-supers" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-replace-supers" "7.0.0-beta.44"
 
-"@babel/plugin-transform-parameters@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.43.tgz#02822d1030daa7f555a2a02fcd7ca460a8bf3828"
+"@babel/plugin-transform-parameters@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.44.tgz#19eaf0b852d58168097435e33e754a00c3507fb9"
   dependencies:
-    "@babel/helper-call-delegate" "7.0.0-beta.43"
-    "@babel/helper-get-function-arity" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-call-delegate" "7.0.0-beta.44"
+    "@babel/helper-get-function-arity" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-regenerator@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.43.tgz#535020663bcc1d72546d6e01b46546de9d8ba347"
+"@babel/plugin-transform-regenerator@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.44.tgz#e9a21db8fbedfd99b9e5d04ac405f7440d36b290"
   dependencies:
     regenerator-transform "^0.12.3"
 
-"@babel/plugin-transform-shorthand-properties@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.43.tgz#357a3ab0067b9689b28a0ad6490c8179f9a2814d"
+"@babel/plugin-transform-shorthand-properties@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.44.tgz#42e2a31aaa5edf479adaf4c2b677cd3457c99991"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-spread@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.43.tgz#6922dadb718b78fc644ba345c58264b2be3c0b74"
+"@babel/plugin-transform-spread@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.44.tgz#94cacc3317cb8e2227b543c25b8046d7635d4114"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-sticky-regex@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.43.tgz#94e1c2e12079cc54d435a285af3fe202a864d387"
+"@babel/plugin-transform-sticky-regex@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.44.tgz#512597cd7535f313aa29f31d0b60572a0374db00"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-regex" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-regex" "7.0.0-beta.44"
 
-"@babel/plugin-transform-template-literals@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.43.tgz#d7451063e9be002d80dc0713009af78c36368d19"
+"@babel/plugin-transform-template-literals@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.44.tgz#88d4605e63a21a4354837af06371e8c51cd76d08"
   dependencies:
-    "@babel/helper-annotate-as-pure" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-annotate-as-pure" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-typeof-symbol@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.43.tgz#b53433041acab36bb12cb09d9bb849998c84b379"
+"@babel/plugin-transform-typeof-symbol@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.44.tgz#ba0ded29aea2a51700e0730a054faa64a22ff38a"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
 
-"@babel/plugin-transform-unicode-regex@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.43.tgz#141826ff3e90543c2e4fe75179c6fb80a566d976"
+"@babel/plugin-transform-unicode-regex@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.44.tgz#d7cf607948da5e997e277eba1caed30e80beaf76"
   dependencies:
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/helper-regex" "7.0.0-beta.43"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/helper-regex" "7.0.0-beta.44"
     regexpu-core "^4.1.3"
 
-"@babel/polyfill@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0-beta.43.tgz#2ba566fd9512a2ca71cda969f6645ce7f885cbbc"
+"@babel/polyfill@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0-beta.44.tgz#6bbcddebd8f28f1040b9a78fdac7dc515356e5dc"
   dependencies:
     core-js "^2.5.3"
     regenerator-runtime "^0.11.1"
 
-"@babel/preset-env@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.0.0-beta.43.tgz#2076748aaaf780c61e1bc65fe282097870843975"
+"@babel/preset-env@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.0.0-beta.44.tgz#9d3df27d81b134cae8a52a36279402aadad6d5d2"
   dependencies:
-    "@babel/helper-module-imports" "7.0.0-beta.43"
-    "@babel/helper-plugin-utils" "7.0.0-beta.43"
-    "@babel/plugin-proposal-async-generator-functions" "7.0.0-beta.43"
-    "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.43"
-    "@babel/plugin-proposal-optional-catch-binding" "7.0.0-beta.43"
-    "@babel/plugin-proposal-unicode-property-regex" "7.0.0-beta.43"
-    "@babel/plugin-syntax-async-generators" "7.0.0-beta.43"
-    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.43"
-    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.43"
-    "@babel/plugin-transform-arrow-functions" "7.0.0-beta.43"
-    "@babel/plugin-transform-async-to-generator" "7.0.0-beta.43"
-    "@babel/plugin-transform-block-scoped-functions" "7.0.0-beta.43"
-    "@babel/plugin-transform-block-scoping" "7.0.0-beta.43"
-    "@babel/plugin-transform-classes" "7.0.0-beta.43"
-    "@babel/plugin-transform-computed-properties" "7.0.0-beta.43"
-    "@babel/plugin-transform-destructuring" "7.0.0-beta.43"
-    "@babel/plugin-transform-dotall-regex" "7.0.0-beta.43"
-    "@babel/plugin-transform-duplicate-keys" "7.0.0-beta.43"
-    "@babel/plugin-transform-exponentiation-operator" "7.0.0-beta.43"
-    "@babel/plugin-transform-for-of" "7.0.0-beta.43"
-    "@babel/plugin-transform-function-name" "7.0.0-beta.43"
-    "@babel/plugin-transform-literals" "7.0.0-beta.43"
-    "@babel/plugin-transform-modules-amd" "7.0.0-beta.43"
-    "@babel/plugin-transform-modules-commonjs" "7.0.0-beta.43"
-    "@babel/plugin-transform-modules-systemjs" "7.0.0-beta.43"
-    "@babel/plugin-transform-modules-umd" "7.0.0-beta.43"
-    "@babel/plugin-transform-new-target" "7.0.0-beta.43"
-    "@babel/plugin-transform-object-super" "7.0.0-beta.43"
-    "@babel/plugin-transform-parameters" "7.0.0-beta.43"
-    "@babel/plugin-transform-regenerator" "7.0.0-beta.43"
-    "@babel/plugin-transform-shorthand-properties" "7.0.0-beta.43"
-    "@babel/plugin-transform-spread" "7.0.0-beta.43"
-    "@babel/plugin-transform-sticky-regex" "7.0.0-beta.43"
-    "@babel/plugin-transform-template-literals" "7.0.0-beta.43"
-    "@babel/plugin-transform-typeof-symbol" "7.0.0-beta.43"
-    "@babel/plugin-transform-unicode-regex" "7.0.0-beta.43"
+    "@babel/helper-module-imports" "7.0.0-beta.44"
+    "@babel/helper-plugin-utils" "7.0.0-beta.44"
+    "@babel/plugin-proposal-async-generator-functions" "7.0.0-beta.44"
+    "@babel/plugin-proposal-object-rest-spread" "7.0.0-beta.44"
+    "@babel/plugin-proposal-optional-catch-binding" "7.0.0-beta.44"
+    "@babel/plugin-proposal-unicode-property-regex" "7.0.0-beta.44"
+    "@babel/plugin-syntax-async-generators" "7.0.0-beta.44"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.44"
+    "@babel/plugin-syntax-optional-catch-binding" "7.0.0-beta.44"
+    "@babel/plugin-transform-arrow-functions" "7.0.0-beta.44"
+    "@babel/plugin-transform-async-to-generator" "7.0.0-beta.44"
+    "@babel/plugin-transform-block-scoped-functions" "7.0.0-beta.44"
+    "@babel/plugin-transform-block-scoping" "7.0.0-beta.44"
+    "@babel/plugin-transform-classes" "7.0.0-beta.44"
+    "@babel/plugin-transform-computed-properties" "7.0.0-beta.44"
+    "@babel/plugin-transform-destructuring" "7.0.0-beta.44"
+    "@babel/plugin-transform-dotall-regex" "7.0.0-beta.44"
+    "@babel/plugin-transform-duplicate-keys" "7.0.0-beta.44"
+    "@babel/plugin-transform-exponentiation-operator" "7.0.0-beta.44"
+    "@babel/plugin-transform-for-of" "7.0.0-beta.44"
+    "@babel/plugin-transform-function-name" "7.0.0-beta.44"
+    "@babel/plugin-transform-literals" "7.0.0-beta.44"
+    "@babel/plugin-transform-modules-amd" "7.0.0-beta.44"
+    "@babel/plugin-transform-modules-commonjs" "7.0.0-beta.44"
+    "@babel/plugin-transform-modules-systemjs" "7.0.0-beta.44"
+    "@babel/plugin-transform-modules-umd" "7.0.0-beta.44"
+    "@babel/plugin-transform-new-target" "7.0.0-beta.44"
+    "@babel/plugin-transform-object-super" "7.0.0-beta.44"
+    "@babel/plugin-transform-parameters" "7.0.0-beta.44"
+    "@babel/plugin-transform-regenerator" "7.0.0-beta.44"
+    "@babel/plugin-transform-shorthand-properties" "7.0.0-beta.44"
+    "@babel/plugin-transform-spread" "7.0.0-beta.44"
+    "@babel/plugin-transform-sticky-regex" "7.0.0-beta.44"
+    "@babel/plugin-transform-template-literals" "7.0.0-beta.44"
+    "@babel/plugin-transform-typeof-symbol" "7.0.0-beta.44"
+    "@babel/plugin-transform-unicode-regex" "7.0.0-beta.44"
     browserslist "^3.0.0"
     invariant "^2.2.2"
     semver "^5.3.0"
 
-"@babel/template@7.0.0-beta.43":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.43.tgz#0d34fa1da16835b23dd136b942c753ad97540c24"
+"@babel/template@7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
-    babylon "7.0.0-beta.43"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/traverse@7.0.0-beta.43", "@babel/traverse@^7.0.0-beta.40":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.43.tgz#dad8700f1e51ed960de22c5060bf1c3e8c8fc494"
+"@babel/traverse@7.0.0-beta.44", "@babel/traverse@^7.0.0-beta.40":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.44.tgz#a970a2c45477ad18017e2e465a0606feee0d2966"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.43"
-    "@babel/generator" "7.0.0-beta.43"
-    "@babel/helper-function-name" "7.0.0-beta.43"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.43"
-    "@babel/types" "7.0.0-beta.43"
-    babylon "7.0.0-beta.43"
+    "@babel/code-frame" "7.0.0-beta.44"
+    "@babel/generator" "7.0.0-beta.44"
+    "@babel/helper-function-name" "7.0.0-beta.44"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.44"
+    babylon "7.0.0-beta.44"
     debug "^3.1.0"
     globals "^11.1.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/types@7.0.0-beta.43", "@babel/types@^7.0.0-beta.40":
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.43.tgz#9d82c2d773b6baec0474ddb774eafd7fb4511f8b"
+"@babel/types@7.0.0-beta.44", "@babel/types@^7.0.0-beta.40":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
@@ -516,12 +516,12 @@
     samsam "1.3.0"
 
 "@types/node@*":
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.1.tgz#e2d374ef15b315b48e7efc308fa1a7cd51faa06c"
+  version "9.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.2.tgz#e49ac1adb458835e95ca6487bc20f916b37aff23"
 
 "@types/node@^8.0.9":
-  version "8.10.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.1.tgz#aac98b810c50568054486f2bb8c486d824713be8"
+  version "8.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.2.tgz#f1fb9c73414832c5b00ee954c4bbf68394e2e526"
 
 "@types/plugin-error@^0.1.0":
   version "0.1.0"
@@ -549,9 +549,9 @@ accepts@~1.3.3, accepts@~1.3.4:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
-accoutrement-color@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/accoutrement-color/-/accoutrement-color-2.2.3.tgz#f9500b6039a53f2854b257a84ffaef1c7290caef"
+accoutrement-color@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/accoutrement-color/-/accoutrement-color-2.3.0.tgz#669623ffcbfd090bd4523804ad52593e85dd7ec4"
 
 accoutrement-init@^1.1.2:
   version "1.1.2"
@@ -561,9 +561,9 @@ accoutrement-layout@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/accoutrement-layout/-/accoutrement-layout-3.0.3.tgz#747c630b24e8989296100c792297ea8ba18a0f47"
 
-accoutrement-scale@^5.0.1:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/accoutrement-scale/-/accoutrement-scale-5.0.2.tgz#2589252f8fd1eaf579a7d9f72343e81efe08259c"
+accoutrement-scale@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/accoutrement-scale/-/accoutrement-scale-6.0.0.tgz#b7c973e319dbe21533ca9e0f57e8a5962d952c45"
 
 accoutrement-type@^4.0.2:
   version "4.0.2"
@@ -1703,9 +1703,9 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@7.0.0-beta.43, babylon@^7.0.0-beta.30, babylon@^7.0.0-beta.40:
-  version "7.0.0-beta.43"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.43.tgz#15128e7403d41b0e56cca2f110024cc1d8ada8cd"
+babylon@7.0.0-beta.44, babylon@^7.0.0-beta.30, babylon@^7.0.0-beta.40:
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
 babylon@^6.17.3, babylon@^6.18.0:
   version "6.18.0"
@@ -2038,8 +2038,8 @@ browser-sync@^2.18.13:
     yargs "6.4.0"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.1.1.tgz#38b7ab55edb806ff2dcda1a7f1620773a477c49f"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   dependencies:
     buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
@@ -2338,12 +2338,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634:
-  version "1.0.30000821"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000821.tgz#3fcdc67c446a94a9cdd848248a4e3e54b2da7419"
+  version "1.0.30000823"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000823.tgz#e68e5f8c70783ef4059d2ea0de81f551651da6fc"
 
 caniuse-lite@^1.0.30000817, caniuse-lite@^1.0.30000821:
-  version "1.0.30000821"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000821.tgz#0f3223f1e048ed96451c56ca6cf197058c42cb93"
+  version "1.0.30000823"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000823.tgz#b79842a5b5a48eaa416b73f5a5d7a23f52d26014"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2551,6 +2551,10 @@ clean-css@4.1.x:
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
+
+cli-command-parser@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cli-command-parser/-/cli-command-parser-1.0.3.tgz#377af3ce60ad2d8a34a7e5eae4b395d491b0d652"
 
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
@@ -3747,8 +3751,8 @@ ejs@^2.3.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.8.tgz#2ab6954619f225e6193b7ac5f7c39c48fefe4380"
 
 electron-to-chromium@^1.3.41:
-  version "1.3.41"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz#7e33643e00cd85edfd17e04194f6d00e73737235"
+  version "1.3.42"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz#95c33bf01d0cc405556aec899fe61fd4d76ea0f9"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7008,12 +7012,13 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-lint-staged@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.0.2.tgz#c99f6800e0525fa9c16f04c13ebe137edfd4fcd7"
+lint-staged@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.0.3.tgz#c2c30bd2821ae9c6043141179b9a03793ad3da08"
   dependencies:
     app-root-path "^2.0.1"
     chalk "^2.3.1"
+    cli-command-parser "^1.0.3"
     commander "^2.14.1"
     cosmiconfig "^4.0.0"
     debug "^3.1.0"
@@ -9587,15 +9592,15 @@ read-pkg@^3.0.0:
     path-type "^3.0.0"
 
 "readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readable-stream@1.1.x, "readable-stream@1.x >=1.1.9", "readable-stream@>=1.1.13-1 <1.2.0-0", readable-stream@~1.1.9:
@@ -10983,7 +10988,7 @@ string@^3.0.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
 
-string_decoder@^1.0.0:
+string_decoder@^1.0.0, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
@@ -10993,7 +10998,7 @@ string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-string_decoder@~1.0.0, string_decoder@~1.0.3:
+string_decoder@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
@@ -12119,9 +12124,9 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.4.1.tgz#b0105789890c28bfce9f392623ef5850254328a4"
+webpack@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.5.0.tgz#1e6f71e148ead02be265ff2879c9cd6bb30b8848"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,9 +549,9 @@ accepts@~1.3.3, accepts@~1.3.4:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
-accoutrement-color@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/accoutrement-color/-/accoutrement-color-2.3.0.tgz#669623ffcbfd090bd4523804ad52593e85dd7ec4"
+accoutrement-color@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/accoutrement-color/-/accoutrement-color-2.3.1.tgz#9466bbd74b394d1dbc36466ad09ca6d566ff35d9"
 
 accoutrement-init@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This makes two changes:

1. `node-sass` is moved to `peerDependencies`, so it uses the project's version by default (and warns if the project does not have node-sass installed).
2. Does not even require `node-sass` if the user doesn't use `@example scss` annotations.

We could go a step further and remove `node-sass` from `peerDependencies` entirely, which would remove the warning for users who don't plan to use it.