### PR TITLE
Allow passing opts through to Sass fn.

### DIFF
--- a/lib/annotations/example.js
+++ b/lib/annotations/example.js
@@ -83,9 +83,11 @@ module.exports = (env) => {
               }
             }
             let sassData = exampleItem.code;
-            let includePaths = [];
-            let importer = sassImporter;
-            let outputStyle = 'expanded';
+            const defaults = {
+              includePaths: [],
+              importer: sassImporter,
+              outputStyle: 'expanded',
+            };
             if (env.herman && env.herman.sass) {
               if (env.herman.sass.includes) {
                 const arr = env.herman.sass.includes;
@@ -108,20 +110,23 @@ module.exports = (env) => {
                 }
               }
               if (env.herman.sass.includePaths) {
-                includePaths = env.herman.sass.includePaths;
+                defaults.includePaths = env.herman.sass.includePaths;
               }
               if (env.herman.sass.importer) {
-                importer = env.herman.sass.importer;
+                defaults.importer = env.herman.sass.importer;
               }
               if (env.herman.sass.outputStyle) {
-                outputStyle = env.herman.sass.outputStyle;
+                defaults.outputStyle = env.herman.sass.outputStyle;
               }
             }
+            console.log({
+              ...defaults,
+              ...env.herman.sass.sassOptions,
+            });
             const promise = renderSass({
+              ...defaults,
+              ...env.herman.sass.sassOptions,
               data: sassData,
-              importer,
-              includePaths,
-              outputStyle,
             })
               .then((rendered) => {
                 const encoded = rendered.css.toString('utf-8');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,9 @@ const sassDocOpts = {
         path.join(__dirname, 'node_modules'),
       ],
       use: ['utilities', 'config', 'samples'],
+      sassOptions: {
+        quietDeps: true,
+      },
     },
   },
   display: {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&foobar)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description

This was an initial attempt to allow passing `quietDeps` (and other arbitrary Sass options) through when using Herman. I'm putting it on hold, though, since I can't even get `quietDeps` to actually, ya know, hide the deprecation messages. I think this is still a decent nice-to-have, but it's not urgent.