### PR TITLE
Use key instead of value for map-compile

### DIFF
--- a/scss/utilities/_maps.scss
+++ b/scss/utilities/_maps.scss
@@ -117,7 +117,7 @@
     $output: map.merge(
       $output,
       (
-        $key: meta.call($function, $value, $args...),
+        $key: meta.call($function, $key, $args...),
       )
     );
   }

--- a/test/sass/utilities/_maps.scss
+++ b/test/sass/utilities/_maps.scss
@@ -17,6 +17,14 @@
 @use '../../../scss/utilities/json-api' as *;
 @use '../../../scss/utilities/maps' as *;
 
+@function compile-keys-test($key, $map) {
+  @if map.has-key($map, $key) {
+    @return 'great!';
+  }
+
+  @return null;
+}
+
 $colors-initial: (
   'brand-blue': hsl(195, 85%, 35%),
   'light-gray': '#brand-blue'
@@ -79,6 +87,19 @@ $sizes-compiled: (
       compile($colors-compiled, meta.get-function('darken'), 20%),
       $darken,
       $inspect: true
+    );
+  }
+
+  @include true.it('runs compilation on the key rather than the map') {
+    $test: (
+      'a': 'hello world',
+    );
+
+    @include true.assert-equal(
+      compile($test, meta.get-function('compile-keys-test'), $test),
+      (
+        'a': 'great!',
+      )
     );
   }
 }


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&eyes)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

## Description

By compiling keys rather than values, we avoid an error in Accoutrement.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

Run the tests wit/without the changes to the compile utility.
