### PR TITLE
Allow copying source-map with customCSS file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-*.css.map
 *.DS_Store
-*.js.map
 *.log
 *.orig
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- 🚀 NEW: Add `customSourceMap` option (default: `customCSS` option + `.map`)
+  to allow copying source-map file along with `customCSS` file
 - 💥 BREAKING: Drop support for Node < 14
 - 💥 BREAKING: `utilities.add()`
   no longer supports map-compilation functions and arguments,

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -139,6 +139,17 @@ to impact the design of those previews.
 [public-path]: https://github.com/webpack-contrib/mini-css-extract-plugin#publicpath
 [css-loader]: https://github.com/webpack-contrib/css-loader#url
 
+## customSourceMap
+
+- Type: `String` or `false`
+- Default: `customCSS + '.map'` if `customCSS` option is defined, otherwise `''`
+
+Relative path to a custom CSS source-map file,
+presumably referenced from the file specified in the `customCSS` option.
+If `customCSS` is defined, this defaults to the `customCSS` path
+with `'.map'` appended.
+To opt out of this feature, set `customSourceMap` to `false`.
+
 ## customHTML
 
 - Type: `String`

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -31,7 +31,7 @@ export const setSearchStore = (val) => {
 
 export const getSearchStore = () => searchStore;
 
-export const getUrlParams = () => deparam(window.location.search.substr(1));
+export const getUrlParams = () => deparam(window.location.search.substring(1));
 
 const getSearchResultsByField = (matches) => {
   const results = {

--- a/lib/annotations/font.js
+++ b/lib/annotations/font.js
@@ -44,8 +44,8 @@ module.exports = (env) => {
       let args = raw;
       if (linebreak > -1) {
         // Multiline annotation; separate first-line args from following HTML
-        args = raw.substr(0, linebreak);
-        const html = raw.substr(linebreak + 1);
+        args = raw.substring(0, linebreak);
+        const html = raw.substring(linebreak + 1);
         obj.html = stripIndent(html.replace(/^\n|\n$/g, ''));
         // Concatenate all font HTML to include in `@example` annotations
         if (!env.fontsHTML || !env.fontsHTML.includes(obj.html)) {

--- a/lib/renderHerman.js
+++ b/lib/renderHerman.js
@@ -87,6 +87,7 @@ const renderHerman = (origDest, ctx) => {
     }),
   ];
 
+  // Copy custom CSS asset
   if (ctx.customCSS) {
     promises.push(
       copy(ctx.customCSS.path, path.resolve(dest, 'assets/custom'), {
@@ -100,6 +101,19 @@ const renderHerman = (origDest, ctx) => {
         }
         return Promise.resolve();
       }),
+    );
+  }
+
+  // Copy custom source-map asset
+  if (
+    (ctx.customCSS || ctx.herman.customSourceMap) &&
+    ctx.herman.customSourceMap !== false
+  ) {
+    promises.push(
+      copy(
+        ctx.herman.customSourceMap || `${ctx.customCSS.path}.map`,
+        path.resolve(dest, 'assets/custom'),
+      ),
     );
   }
 

--- a/lib/utils/parse.js
+++ b/lib/utils/parse.js
@@ -124,9 +124,9 @@ module.exports = {
     return resp;
   },
   customCSS: (file, enc, env) => {
-    // Parse the contents of a file containing CSS output. For any occurences of
-    // `url(...)` with relative paths, store the paths (for later copying) and
-    // replace them with the eventual destination paths.
+    // Parse the contents of a file containing CSS output. For any occurrences
+    // of `url(...)` with relative paths, store the paths (for later copying)
+    // and replace them with the eventual destination paths.
     env.customCSSFiles = env.customCSSFiles || [];
     let css = file.contents.toString(enc);
     const regex = /url\((["']?)(?:(?=(\\?))\2.)*?\1\)/g;
@@ -164,7 +164,9 @@ module.exports = {
           const baseFontPath = `${path.resolve(env.dir, env.herman.fontPath)}${
             path.sep
           }`;
-          const rel_path = abs_path.substr(unixify(baseFontPath, false).length);
+          const rel_path = abs_path.substring(
+            unixify(baseFontPath, false).length,
+          );
           new_path = `../fonts/${rel_path}`;
         } else {
           const rel_path = path.posix.relative(unixify(env.dir), abs_path);
@@ -172,8 +174,8 @@ module.exports = {
           // Store reference to original path for later copying of assets
           env.customCSSFiles.push(path.resolve(abs_path));
         }
-        const pre = css.substr(0, start_index);
-        const post = css.substr(start_index + src_path.length);
+        const pre = css.substring(0, start_index);
+        const post = css.substring(start_index + src_path.length);
         css = pre + new_path + post;
       }
     }

--- a/sassdoc-webpack-plugin.js
+++ b/sassdoc-webpack-plugin.js
@@ -15,7 +15,7 @@ const getAsset = function (entry, ext = 'css') {
   }
   let asset;
   for (const thisPath of entry) {
-    if (thisPath.substr(0 - (ext.length + 1)) === `.${ext}`) {
+    if (thisPath.slice(0 - (ext.length + 1)) === `.${ext}`) {
       asset = thisPath;
     }
   }

--- a/test/js/fixtures/css/main.css
+++ b/test/js/fixtures/css/main.css
@@ -1,0 +1,5 @@
+body {
+  border: 1px;
+}
+
+/*# sourceMappingURL=main.css.map */

--- a/test/js/fixtures/css/main.css.map
+++ b/test/js/fixtures/css/main.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sourceRoot":"","sources":["../scss/import.scss"],"names":[],"mappings":"AAAA;EACE","file":"main.css"}

--- a/test/js/fixtures/css/other.css.map
+++ b/test/js/fixtures/css/other.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sourceRoot":"","sources":["../scss/import.scss"],"names":[],"mappings":"AAAA;EACE","file":"main.css"}

--- a/test/js/testRenderHerman.js
+++ b/test/js/testRenderHerman.js
@@ -127,11 +127,62 @@ describe('renderHerman', () => {
     })
       .then((ctx) => renderHerman(this.dest, ctx))
       .then(() => access(`${this.dest}/assets/custom/main.css`))
+      .then(() => access(`${this.dest}/assets/custom/main.css.map`))
       .then(() => {
         assert.ok(true);
         done();
       })
       .catch(done);
+  });
+
+  it('handles customSourceMap option', function (done) {
+    prepareContext({
+      data: [],
+      customCSS: {
+        path: `${__dirname}/fixtures/css/main.css`,
+      },
+      herman: {
+        customSourceMap: `${__dirname}/fixtures/css/other.css.map`,
+      },
+    })
+      .then((ctx) => renderHerman(this.dest, ctx))
+      .then(() => access(`${this.dest}/assets/custom/other.css.map`))
+      .then(() => {
+        assert.ok(true);
+      })
+      .then(() => access(`${this.dest}/assets/custom/main.css.map`))
+      .then(() => {
+        // The file should not have been copied
+        assert.fail();
+        done();
+      })
+      .catch(() => {
+        assert.ok(true);
+        done();
+      });
+  });
+
+  it('handles customSourceMap: false', function (done) {
+    prepareContext({
+      data: [],
+      customCSS: {
+        path: `${__dirname}/fixtures/css/main.css`,
+      },
+      herman: {
+        customSourceMap: false,
+      },
+    })
+      .then((ctx) => renderHerman(this.dest, ctx))
+      .then(() => access(`${this.dest}/assets/custom/main.css.map`))
+      .then(() => {
+        // The file should not have been copied
+        assert.fail();
+        done();
+      })
+      .catch(() => {
+        assert.ok(true);
+        done();
+      });
   });
 
   it('handles customCSSFiles', function (done) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,6 +101,7 @@ module.exports = {
     path: outputPath,
     publicPath: '/assets/webpack/',
     filename: '[name].min.js',
+    clean: true,
   },
   resolve: {
     // where to look for "required" modules
@@ -148,6 +149,10 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: '[name].min.css',
     }),
+    new webpack.SourceMapDevToolPlugin({
+      exclude: /json/,
+      filename: '[file].map',
+    }),
     new SassDocPlugin(sassDocOpts, {
       assetPaths: [
         { entry: 'app_styles', optPath: 'herman.customCSS' },
@@ -186,10 +191,12 @@ module.exports = {
             options: {
               url: false,
               importLoaders: 2,
+              sourceMap: true,
             },
           },
           {
             loader: 'postcss-loader',
+            options: { sourceMap: true },
           },
           {
             loader: 'sass-loader',
@@ -197,11 +204,12 @@ module.exports = {
               sassOptions: {
                 quietDeps: true,
               },
+              sourceMap: true,
             },
           },
         ],
       },
     ],
   },
-  devtool: 'source-map',
+  devtool: false,
 };


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&220812)

## Description

Before, when users pass in a custom CSS file to include in their styleguide, we didn't give any way for that file to include a source-map file. Now we default to copying in a corresponding `.map` file (if it exists), but also provide an option for users to pass a custom source-map file path or disable the feature entirely.