### PR TITLE
show keywords as border in previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   [#338](https://github.com/oddbird/sassdoc-theme-herman/issues/338)
 - 🚀 NEW: Add support for non-standard CSS font-weight names --
   [#250](https://github.com/oddbird/sassdoc-theme-herman/issues/250)
+- 🚀 NEW: Length keywords in `@sizes {ruler}` maps will display as a border
 - 🏠 INTERNAL: Include source-maps with Herman JS & CSS assets
 - 🏠 INTERNAL: Upgrade dependencies
 - 🏠 INTERNAL: Remove documentation static-site from repository

--- a/scss/config/_scale.scss
+++ b/scss/config/_scale.scss
@@ -125,9 +125,6 @@ $spacing-sizes: (
 /// @sizes {ruler}
 /// @group config-scale
 $pattern-sizes: (
-  'outline': thin,
-  'border': medium,
-  'separator': thick,
   'nav-underline': 4px,
   'nav-icon': 28px,
   'arrow-border': 8px,

--- a/scss/config/_scale.scss
+++ b/scss/config/_scale.scss
@@ -125,6 +125,9 @@ $spacing-sizes: (
 /// @sizes {ruler}
 /// @group config-scale
 $pattern-sizes: (
+  'outline': thin,
+  'border': medium,
+  'separator': thick,
   'nav-underline': 4px,
   'nav-icon': 28px,
   'arrow-border': 8px,

--- a/scss/iframes/_size.scss
+++ b/scss/iframes/_size.scss
@@ -29,9 +29,16 @@
   --herman-label-color: #{tools.color('callout')};
 }
 
+[data-herman-border] {
+  --herman-size-bar: #{tools.color('slight')};
+  --herman-size-bar-image: none;
+}
+
 [data-herman-viz='bar'] {
   background-color: var(--herman-size-bar, #{tools.color('border')});
-  background-image: linear-gradient(
+  background-image: var(
+    --herman-size-bar-image,
+    linear-gradient(
       to left,
       tools.color('underline') 1px,
       transparent 1px,
@@ -60,7 +67,8 @@
         1px,
       transparent 1px,
       transparent
-    );
+    )
+  );
   background-position: 0 100%;
   background-repeat: repeat-x;
   background-size: 100px 75%, 10px 50%, 5px 25%;

--- a/scss/samples/_sizes-ratios.scss
+++ b/scss/samples/_sizes-ratios.scss
@@ -91,7 +91,7 @@ $demo-ratios: (
 /// [ac]: https://www.oddbird.net/accoutrement/
 ///
 /// ```scss
-/// $demo-sizes: (
+/// $demo-sizes-text: (
 ///   'root': $root,
 ///   'xlarge': $xlarge
 /// );
@@ -123,10 +123,18 @@ $demo-ratios: (
 ///   - `output-only`: Displays values only, without demonstration.
 ///
 /// @group demo_sizes
-$demo-sizes: (
+$demo-sizes-text: (
   'root': $root,
   'responsive': calc(1.5em + 1vw),
   'xlarge': $xlarge,
+);
+$demo-sizes-theme: (
+  'icon': 1rem,
+  'card': 30vw,
+  'quote': 50%,
+  'outline': thin,
+  'border': medium,
+  'separator': thick,
 );
 $demo-sizes-large: (
   'box': 20em,
@@ -135,16 +143,16 @@ $demo-sizes-large: (
 
 /// ### Text Sizes
 /// ```scss
-/// /// @sizes demo-sizes {text}
+/// /// @sizes demo-sizes-text {text}
 /// ```
-/// @sizes demo-sizes {text}
+/// @sizes demo-sizes-text {text}
 /// @group demo_sizes
 
 /// ### Rulers
 /// ```scss
-/// /// @sizes demo-sizes {ruler}
+/// /// @sizes demo-sizes-theme {ruler}
 /// ```
-/// @sizes demo-sizes {ruler}
+/// @sizes demo-sizes-theme {ruler}
 /// @group demo_sizes
 
 /// ### Large Rulers
@@ -156,14 +164,14 @@ $demo-sizes-large: (
 
 /// ### Name/Value Only
 /// ```scss
-/// /// @sizes demo-sizes {output-only}
+/// /// @sizes demo-sizes-text {output-only}
 /// ```
-/// @sizes demo-sizes {output-only}
+/// @sizes demo-sizes-text {output-only}
 /// @group demo_sizes
 
 /// ## Add ratio/size data to $herman
 ///
-/// In order to preview the `$demo-ratios` and `$demo-sizes` maps,
+/// In order to preview the `$demo-ratios` and `$demo-sizes-*` maps,
 /// we also need to [export the data to JSON][export].
 ///
 /// You can add data to the `$herman` export-map by hand,
@@ -173,7 +181,9 @@ $demo-sizes-large: (
 ///
 /// ```scss
 ///  @include add('ratios', 'demo-ratios', $demo-ratios);
-///  @include add('sizes', 'demo-sizes', $demo-sizes);
+///  @include add('sizes', 'demo-sizes-text', $demo-sizes-text);
+///  @include add('sizes', 'demo-sizes-theme', $demo-sizes-theme);
+///  @include add('sizes', 'demo-sizes-large', $demo-sizes-large);
 /// ```
 ///
 /// If your map needs to be parsed or compiled before export,
@@ -190,5 +200,6 @@ $demo-sizes-large: (
 /// @group demo_sizes
 /// @link https://www.oddbird.net/accoutrement Accoutrement
 @include utilities.add('ratios', 'demo-ratios', $demo-ratios);
-@include utilities.add('sizes', 'demo-sizes', $demo-sizes);
+@include utilities.add('sizes', 'demo-sizes-text', $demo-sizes-text);
+@include utilities.add('sizes', 'demo-sizes-theme', $demo-sizes-theme);
 @include utilities.add('sizes', 'demo-sizes-large', $demo-sizes-large);

--- a/templates/item/preview.macros.njk
+++ b/templates/item/preview.macros.njk
@@ -294,7 +294,7 @@
     <td aria-hidden data-herman-cell="viz" {% if colspan %}colspan="{{ colspan }}"{% endif %}>
       <div data-herman-size="overflow">
         {% if width %}
-          {% if value == 'thin' or value == 'thick' or value == 'medium' %}
+          {% if value in ['thin', 'thick', 'medium'] %}
             <div data-herman-viz="bar" data-herman-border style="border-width: {{ width }};">
           {% else %}
             <div data-herman-viz="bar" style="width: {{ width }};">

--- a/templates/item/preview.macros.njk
+++ b/templates/item/preview.macros.njk
@@ -293,8 +293,12 @@
   {% if width or text %}
     <td aria-hidden data-herman-cell="viz" {% if colspan %}colspan="{{ colspan }}"{% endif %}>
       <div data-herman-size="overflow">
-      {% if width %}
-        <div data-herman-viz="bar" style="width: {{ width }};">
+        {% if width %}
+          {% if value == 'thin' or value == 'thick' or value == 'medium' %}
+            <div data-herman-viz="bar" data-herman-border style="border-width: {{ width }};">
+          {% else %}
+            <div data-herman-viz="bar" style="width: {{ width }};">
+          {% endif %}
           &nbsp;
         </div>
       {% elif text %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,6 +136,9 @@ module.exports = {
   devServer: {
     static: [path.join(__dirname, 'docs')],
     hot: false,
+    devMiddleware: {
+      writeToDisk: true,
+    },
   },
   plugins: [
     // make jquery accessible in all modules that use it


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&afadfffas)

## Description
When using a keyword like medium for a size (that is part of a @sizes {ruler} map), show those as borders instead of the typical ruler. 

## Steps to test/reproduce
If running locally, visit the config-scale.html page, look at the pattern sizes (these should be moved to demo)

## Show me
![Screen Shot 2022-08-18 at 9 36 59 AM](https://user-images.githubusercontent.com/1581694/185422397-9bd01c94-0e07-479e-ac72-7282db4e5b95.jpg)

# REMEMBER: Attach this PR to the Trello card
https://trello.com/c/gAFt8dMk/59-herman-how-should-length-keywords-like-a-medium-border-width-be-previewed


## To do

- [x] move border demos to the demo_sizes.html instead of the sizes design tokens
- [x] see if there's a better way to write `{% if value == 'thin' or value == 'thick' or value == 'medium' %}`