### PR TITLE
Support newer Sass `pkg` and compiler features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Herman Changelog
 
-## Unreleased
+## 6.0.0-beta.0: Unreleased
 
-- 🏠 INTERNAL: Upgrade dependencies
+### 💥 Breaking Changes
+
+- Require Dart Sass `^1.71.0` for `@example scss` annotations, using the new
+  [Node.js package importer](https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/) as `sass.sassOptions.importers` by default.
+  Older versions of Dart Sass are still supported by explicitly setting
+  `sass.sassOptions.importers`.
+- Remove `sass.importers` option (use `sass.sassOptions.importers` instead).
+- Remove deprecated `sass.includes` option (use `sass.use` instead).
+- Drop support for Node < 18
+
+### 🏠 Internal
+
+- Upgrade to Yarn v4 (without PnP)
+- Add Dependabot for dependency updates going forward
+- Upgrade dependencies
 
 ## 5.0.1: 2022-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Use faster Dart Sass
   [`AsyncCompiler` API](https://sass-lang.com/documentation/js-api/classes/asynccompiler/)
   for `@example scss` annotations.
+- Add `exports.sass` in `package.json` for simpler `pkg:` imports.
 
 ### 💥 Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,27 @@
 
 ## 6.0.0-beta.0: Unreleased
 
+### 🚀 New Features
+
+- Add `sass.implementation` option (`string` or Dart Sass instance) to specify
+  the Dart Sass implementation to use for `@example scss` annotations. (default:
+  `sass`).
+- Use faster Dart Sass
+  [`AsyncCompiler` API](https://sass-lang.com/documentation/js-api/classes/asynccompiler/)
+  for `@example scss` annotations.
+
 ### 💥 Breaking Changes
 
 - Require Dart Sass `^1.71.0` for `@example scss` annotations, using the new
-  [Node.js package importer](https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/) as `sass.sassOptions.importers` by default.
-  Older versions of Dart Sass are still supported by explicitly setting
-  `sass.sassOptions.importers`.
+  [Node.js package importer](https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/) in `sass.sassOptions.importers` by default.
 - Remove `sass.importers` option (use `sass.sassOptions.importers` instead).
 - Remove deprecated `sass.includes` option (use `sass.use` instead).
 - Drop support for Node < 18
 
 ### 🏠 Internal
 
+- Use [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)
+  instead of [`sass`](https://www.npmjs.com/package/sass) internally
 - Upgrade to Yarn v4 (without PnP)
 - Add Dependabot for dependency updates going forward
 - Upgrade dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - Require Dart Sass `^1.71.0` for `@example scss` annotations, using the new
   [Node.js package importer](https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/) in `sass.sassOptions.importers` by default.
+- Remove custom Sass importer that supported `~` imports for external modules.
+  Replace `~` with `pkg:` to use the newer Dart Sass Node.js package importer.
 - Remove `sass.importers` option (use `sass.sassOptions.importers` instead).
 - Remove deprecated `sass.includes` option (use `sass.use` instead).
 - Drop support for Node < 18

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -233,6 +233,20 @@ _Either [`nunjucks.templatePath`](#nunjucks-templatepath) or
 
 Container for the following sass-related options:
 
+### sass.implementation
+
+- Type: `String` or Sass implementation instance
+- Default: `'sass'`
+
+Determines the Sass implementation (defaults to [`sass`][dart-sass]) to use for
+Sass compilation if using [`@example scss` annotation][example-docs-scss]. This
+option expects a string that matches the name of an available Dart Sass
+implementation (e.g. `sass` or `sass-embedded`), or a Dart Sass instance itself.
+
+[dart-sass]: https://www.npmjs.com/package/sass
+[example-docs-scss]: https://www.oddbird.net/herman/docs/demo_examples#compiling-sass-scss
+[sass-embedded]: https://www.npmjs.com/package/sass-embedded
+
 ### sass.jsonFile
 
 - Type: `String`

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -254,21 +254,6 @@ See [Exporting Styles to JSON][export].
 [export]: https://www.oddbird.net/herman/docs/api_json-export
 [export-mixin]: https://www.oddbird.net/herman/docs/api_json-export#mixin--export
 
-### sass.importers
-
-- Type: `Array`
-- Default: `Array` containing the [Herman Sass importer][sass-importer],
-  which supports `~` imports for external modules installed via npm or Yarn.
-
-Array of importer objects
-used to resolve `@use` and `@import` file paths.
-Passed through to the Dart Sass [importers] option when
-compiling `@example sass/scss` annotations.
-See our [`@example` documentation][example-docs-scss].
-
-[sass-importer]: https://github.com/oddbird/sassdoc-theme-herman/blob/main/lib/utils/sassImporter.js
-[importers]: https://sass-lang.com/documentation/js-api/interfaces/Importer
-
 ### sass.use
 
 - Type: `Array`
@@ -305,36 +290,23 @@ as that output will be displayed in every single Sass example.
 
 [dart-sass-modules]: https://sass-lang.com/blog/the-module-system-is-launched
 
-### sass.includes [deprecated]
-
-- Type: `Array`
-- Default: `[]`
-
-List of files (relative to any
-[`sass.sassOptions.loadPaths`](#sass-sassoptions)) to `@import`
-for all `@example sass/scss` annotations.
-See our [`@example` documentation][example-docs-scss].
-
-This is useful for including any global
-Sass configuration and toolkit files
-that may be used by any example.
-It's best to avoid files with output CSS,
-as that output will be displayed in every single Sass example.
-
-**Note:** Use of `@import` is [discouraged];
-prefer the [`sass.use` option](#sass-use) instead.
-
-[example-docs-scss]: https://www.oddbird.net/herman/docs/demo_examples#compiling-sass-scss
-[discouraged]: https://sass-lang.com/documentation/at-rules/import
-
 ### sass.sassOptions
 
 - Type: `Object`
 - Default: `{}`
 
-Options (e.g. `loadPaths` or `style`) that are passed
+Options (e.g. `importers`, `loadPaths`, or `style`) that are passed
 directly through to Dart Sass
 when compiling `@example sass/scss` annotations.
 See the [Dart Sass documentation][dart-sass-docs] for more info.
 
+By default, `importers` is set to an array
+containing the [Node.js package importer][sass-importer],
+which supports `pkg:` imports to resolve `@use` and `@import`
+for external modules installed via npm or Yarn.
+If `sass.sassOptions.importers` is set
+(even as an empty array `importers: []`),
+it will override the default importer.
+
 [dart-sass-docs]: https://sass-lang.com/documentation/js-api/modules#compileStringAsync
+[sass-importer]: https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -307,7 +307,7 @@ as that output will be displayed in every single Sass example.
 ### sass.sassOptions
 
 - Type: `Object`
-- Default: `{}`
+- Default: `{ importers: [new sass.NodePackageImporter()] }`
 
 Options (e.g. `importers`, `loadPaths`, or `style`) that are passed
 directly through to Dart Sass

--- a/lib/annotations/example.js
+++ b/lib/annotations/example.js
@@ -81,6 +81,7 @@ module.exports = (env) => {
                 }
               }
             }
+            /* istanbul ignore else */
             if (sass && !sassCompiler) {
               try {
                 sassCompiler = sass.initAsyncCompiler();

--- a/lib/annotations/example.js
+++ b/lib/annotations/example.js
@@ -23,7 +23,7 @@ module.exports = (env) => {
     // eslint-disable-next-line global-require
     require('sassdoc/dist/annotation/annotations/example').default;
   const baseExample = baseExampleFn();
-  let sass;
+  let sass, sassCompiler;
   return {
     ...baseExample,
     resolve: (data) => {
@@ -61,13 +61,33 @@ module.exports = (env) => {
             exampleItem.rendered = undefined;
             /* istanbul ignore else */
             if (!sass) {
+              if (
+                env.herman?.sass?.implementation &&
+                typeof env.herman.sass.implementation !== 'string'
+              ) {
+                sass = env.herman.sass.implementation;
+              } else {
+                const sassPkg = env.herman?.sass?.implementation ?? 'sass';
+                try {
+                  // eslint-disable-next-line global-require
+                  sass = require(sassPkg);
+                } catch (err) /* istanbul ignore next */ {
+                  env.logger.warn(
+                    `Cannot find Dart Sass (\`${sassPkg}\`) dependency, ` +
+                      'which is required when using the `@example scss` annotation.',
+                  );
+                  env.logger.warn(err);
+                  return;
+                }
+              }
+            }
+            if (sass && !sassCompiler) {
               try {
-                // eslint-disable-next-line global-require
-                sass = require('sass');
+                sassCompiler = sass.initAsyncCompiler();
               } catch (err) /* istanbul ignore next */ {
                 env.logger.warn(
-                  'Cannot find Dart Sass (`sass`) dependency, which is ' +
-                    'required when using `@example scss` annotation.',
+                  'Cannot find Sass `initAsyncCompiler`,' +
+                    ' which is available since Dart Sass v1.70.0.',
                 );
                 env.logger.warn(err);
                 return;
@@ -91,7 +111,7 @@ module.exports = (env) => {
                   }
                 }
               }
-              if (!env.herman.sass.sassOptions?.importers) {
+              if (sass && !env.herman.sass.sassOptions?.importers) {
                 try {
                   sassOptions.importers = [new sass.NodePackageImporter()];
                 } catch (err) /* istanbul ignore next */ {
@@ -109,9 +129,11 @@ module.exports = (env) => {
               };
             }
             /* istanbul ignore else */
-            if (sass) {
-              const promise = sass
-                .compileStringAsync(sassData, sassOptions)
+            if (sass && sassCompiler) {
+              const promise = sassCompiler
+                .then((compiler) =>
+                  compiler.compileStringAsync(sassData, sassOptions),
+                )
                 .then(({ css }) => {
                   exampleItem.rendered = css;
                 })
@@ -124,9 +146,16 @@ module.exports = (env) => {
               sassPromises.push(promise);
             }
           }
-          const iframePromise = Promise.all(sassPromises).then(() =>
-            renderIframe(env, exampleItem, 'example'),
-          );
+          const iframePromise = Promise.all(sassPromises)
+            .then(() => {
+              if (sassCompiler) {
+                sassCompiler.then((compiler) => {
+                  compiler.dispose();
+                });
+                sassCompiler = undefined;
+              }
+            })
+            .then(() => renderIframe(env, exampleItem, 'example'));
           iFramePromises.push(iframePromise);
         });
       });

--- a/lib/annotations/example.js
+++ b/lib/annotations/example.js
@@ -74,15 +74,9 @@ module.exports = (env) => {
               }
             }
             let sassData = exampleItem.code;
-            let sassOptions = { importers: [new sass.NodePackageImporter()] };
+            let sassOptions = {};
             /* istanbul ignore else */
             if (env.herman && env.herman.sass) {
-              if (env.herman.sass.includes) {
-                const arr = env.herman.sass.includes;
-                for (let i = arr.length - 1; i >= 0; i = i - 1) {
-                  sassData = `@import '${arr[i]}';\n${sassData}`;
-                }
-              }
               if (env.herman.sass.use) {
                 const arr = env.herman.sass.use;
                 for (let i = arr.length - 1; i >= 0; i = i - 1) {
@@ -97,8 +91,17 @@ module.exports = (env) => {
                   }
                 }
               }
-              if (env.herman.sass.importers) {
-                sassOptions.importers = env.herman.sass.importers;
+              if (!env.herman.sass.sassOptions?.importers) {
+                try {
+                  sassOptions.importers = [new sass.NodePackageImporter()];
+                } catch (err) /* istanbul ignore next */ {
+                  env.logger.warn(
+                    'Cannot find default importer `sass.NodePackageImporter`,' +
+                      ' which is available since Dart Sass v1.71.0.',
+                  );
+                  env.logger.warn(err);
+                  return;
+                }
               }
               sassOptions = {
                 ...sassOptions,

--- a/lib/annotations/example.js
+++ b/lib/annotations/example.js
@@ -5,6 +5,11 @@ const stripIndent = require('strip-indent');
 
 const renderIframe = require('../renderIframe');
 const getCustomNunjucksEnv = require('../utils/getCustomNunjucksEnv');
+const {
+  getSassImplementation,
+  getSassCompilerPromise,
+  getSassImporters,
+} = require('../utils/sass');
 
 const beautifyOpts = {
   indent_size: 2,
@@ -23,7 +28,7 @@ module.exports = (env) => {
     // eslint-disable-next-line global-require
     require('sassdoc/dist/annotation/annotations/example').default;
   const baseExample = baseExampleFn();
-  let sass, sassCompiler;
+  let sass, sassCompilerPromise;
   return {
     ...baseExample,
     resolve: (data) => {
@@ -61,38 +66,19 @@ module.exports = (env) => {
             exampleItem.rendered = undefined;
             /* istanbul ignore else */
             if (!sass) {
-              if (
-                env.herman?.sass?.implementation &&
-                typeof env.herman.sass.implementation !== 'string'
-              ) {
-                sass = env.herman.sass.implementation;
-              } else {
-                const sassPkg = env.herman?.sass?.implementation ?? 'sass';
-                try {
-                  // eslint-disable-next-line global-require
-                  sass = require(sassPkg);
-                } catch (err) /* istanbul ignore next */ {
-                  env.logger.warn(
-                    `Cannot find Dart Sass (\`${sassPkg}\`) dependency, ` +
-                      'which is required when using the `@example scss` annotation.',
-                  );
-                  env.logger.warn(err);
-                  return;
-                }
-              }
+              sass = getSassImplementation(env);
+            }
+            /* istanbul ignore if */
+            if (!sass) {
+              return;
             }
             /* istanbul ignore else */
-            if (sass && !sassCompiler) {
-              try {
-                sassCompiler = sass.initAsyncCompiler();
-              } catch (err) /* istanbul ignore next */ {
-                env.logger.warn(
-                  'Cannot find Sass `initAsyncCompiler`,' +
-                    ' which is available since Dart Sass v1.70.0.',
-                );
-                env.logger.warn(err);
-                return;
-              }
+            if (!sassCompilerPromise) {
+              sassCompilerPromise = getSassCompilerPromise(env, sass);
+            }
+            /* istanbul ignore if */
+            if (!sassCompilerPromise) {
+              return;
             }
             let sassData = exampleItem.code;
             let sassOptions = {};
@@ -112,48 +98,36 @@ module.exports = (env) => {
                   }
                 }
               }
-              if (sass && !env.herman.sass.sassOptions?.importers) {
-                try {
-                  sassOptions.importers = [new sass.NodePackageImporter()];
-                } catch (err) /* istanbul ignore next */ {
-                  env.logger.warn(
-                    'Cannot find default importer `sass.NodePackageImporter`,' +
-                      ' which is available since Dart Sass v1.71.0.',
-                  );
-                  env.logger.warn(err);
-                  return;
-                }
+              if (!env.herman.sass.sassOptions?.importers) {
+                sassOptions.importers = getSassImporters(env, sass);
               }
               sassOptions = {
                 ...sassOptions,
                 ...env.herman.sass.sassOptions,
               };
             }
-            /* istanbul ignore else */
-            if (sass && sassCompiler) {
-              const promise = sassCompiler
-                .then((compiler) =>
-                  compiler.compileStringAsync(sassData, sassOptions),
-                )
-                .then(({ css }) => {
-                  exampleItem.rendered = css;
-                })
-                .catch((err) => {
-                  env.logger.warn(
-                    'Error compiling @example scss: \n' +
-                      `${err.message}\n${sassData}`,
-                  );
-                });
-              sassPromises.push(promise);
-            }
+            const promise = sassCompilerPromise
+              .then((compiler) =>
+                compiler.compileStringAsync(sassData, sassOptions),
+              )
+              .then(({ css }) => {
+                exampleItem.rendered = css;
+              })
+              .catch((err) => {
+                env.logger.warn(
+                  'Error compiling @example scss: \n' +
+                    `${err.message}\n${sassData}`,
+                );
+              });
+            sassPromises.push(promise);
           }
           const iframePromise = Promise.all(sassPromises)
-            .then(() => {
-              if (sassCompiler) {
-                sassCompiler.then((compiler) => {
+            .finally(() => {
+              if (sassCompilerPromise) {
+                sassCompilerPromise.then((compiler) => {
                   compiler.dispose();
                 });
-                sassCompiler = undefined;
+                sassCompilerPromise = null;
               }
             })
             .then(() => renderIframe(env, exampleItem, 'example'));

--- a/lib/utils/sass.js
+++ b/lib/utils/sass.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Returns Sass implementation (or `null`)
+const getSassImplementation = (env) => {
+  if (
+    env.herman?.sass?.implementation &&
+    typeof env.herman.sass.implementation !== 'string'
+  ) {
+    return env.herman.sass.implementation;
+  }
+  const sassPkg = env.herman?.sass?.implementation ?? 'sass';
+  try {
+    // eslint-disable-next-line global-require
+    return require(sassPkg);
+  } catch (err) /* istanbul ignore next */ {
+    env.logger.warn(
+      `Cannot find Dart Sass (\`${sassPkg}\`) dependency, ` +
+        'which is required when using the `@example scss` annotation.',
+    );
+    env.logger.warn(err);
+    return null;
+  }
+};
+
+// Returns Promise that resolves with Sass AsyncCompiler (or `null`)
+const getSassCompilerPromise = (env, sass) => {
+  try {
+    return sass.initAsyncCompiler();
+  } catch (err) /* istanbul ignore next */ {
+    env.logger.warn(
+      'Cannot find Sass `initAsyncCompiler`,' +
+        ' which is available since Dart Sass v1.70.0.',
+    );
+    env.logger.warn(err);
+    return null;
+  }
+};
+
+// Returns array of default Sass importers (`NodePackageImporter`)
+const getSassImporters = (env, sass) => {
+  try {
+    return [new sass.NodePackageImporter()];
+  } catch (err) /* istanbul ignore next */ {
+    env.logger.warn(
+      'Cannot find default importer `sass.NodePackageImporter`,' +
+        ' which is available since Dart Sass v1.71.0.',
+    );
+    env.logger.warn(err);
+    return [];
+  }
+};
+
+module.exports = {
+  getSassImplementation,
+  getSassCompilerPromise,
+  getSassImporters,
+};

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "cdocparser": "^0.15.0"
   },
   "lint-staged": {
-    "*.{js,cjs,ts,md}": [
+    "*.{js,cjs,ts}": [
       "eslint --fix",
       "prettier --write --ignore-unknown"
     ],
@@ -150,7 +150,7 @@
       "stylelint --fix --allow-empty-input",
       "prettier --write --ignore-unknown"
     ],
-    "*.{json,yml}": [
+    "*.{json,yml,md}": [
       "prettier --write --ignore-unknown"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   "keywords": [
     "sassdoc-theme"
   ],
+  "main": "./index.js",
+  "exports": {
+    "sass": "./sass/_utilities.scss",
+    "default": "./index.js"
+  },
   "files": [
     "index.js",
     "dist/",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "postcss-loader": "^8.1.0",
     "prettier": "^3.2.5",
     "sass": "^1.71.1",
+    "sass-embedded": "^1.71.1",
     "sass-loader": "^14.1.1",
     "sass-true": "^7.0.1",
     "sassdoc": "^2.7.4",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "sass": "^1.71.1",
     "sass-embedded": "^1.71.1",
     "sass-loader": "^14.1.1",
-    "sass-true": "^7.0.1",
+    "sass-true": "^8.0.0",
     "sassdoc": "^2.7.4",
     "sinon": "^17.0.1",
     "srcdoc-polyfill": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "main": "./index.js",
   "exports": {
-    "sass": "./sass/_utilities.scss",
+    "sass": "./scss/_utilities.scss",
     "default": "./index.js"
   },
   "files": [

--- a/scss/component/_breadcrumb.scss
+++ b/scss/component/_breadcrumb.scss
@@ -4,7 +4,7 @@
 /// So you always know where you are…
 /// @group component-breadcrumb
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 // Breadcrumb
 // ----------

--- a/scss/component/_footer.scss
+++ b/scss/component/_footer.scss
@@ -23,7 +23,7 @@
 ///     </span>
 ///   </aside>
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 @use '../config';
 
 /// Layout for the footer credit.

--- a/scss/component/_item.scss
+++ b/scss/component/_item.scss
@@ -1,7 +1,7 @@
 // Item Styles
 // ===========
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 .item {
   margin-bottom: tools.size('spacer');

--- a/scss/component/_nav.scss
+++ b/scss/component/_nav.scss
@@ -3,7 +3,7 @@
 /// # Herman Navigation Components
 /// @group component-nav
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 @use '../config';
 
 // Nav Lists

--- a/scss/component/_project-meta.scss
+++ b/scss/component/_project-meta.scss
@@ -1,7 +1,7 @@
 // Project Meta Styles
 // ===================
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 @use '../config';
 
 .project-links {

--- a/scss/component/_search.scss
+++ b/scss/component/_search.scss
@@ -1,7 +1,7 @@
 // Search
 // ======
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 .search-heading {
   font-size: tools.size('h1');

--- a/scss/config/_abstracts.scss
+++ b/scss/config/_abstracts.scss
@@ -1,7 +1,7 @@
 @use 'sass:list';
 @use 'sass:meta';
 @use '../utilities';
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 // Accoutrement Utils
 // ==================

--- a/scss/config/_banner.scss
+++ b/scss/config/_banner.scss
@@ -4,7 +4,7 @@
 /// Styles related to the top banner in generated Herman docs.
 /// @group style-banner
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 // Banner Arrow
 // ------------

--- a/scss/config/_index.scss
+++ b/scss/config/_index.scss
@@ -1,4 +1,4 @@
-@use 'pkg:accoutrement/sass/tools' with (
+@use 'pkg:accoutrement' as tools with (
   $color-var-prefix: 'herman-'
 );
 

--- a/scss/config/_type.scss
+++ b/scss/config/_type.scss
@@ -1,7 +1,7 @@
 // Typography Config
 // =================
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 /// ## macro `link_if()`
 /// This Nunjucks utility macro returns either

--- a/scss/config/_z-index.scss
+++ b/scss/config/_z-index.scss
@@ -1,7 +1,7 @@
 // Z-Index
 // =======
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 /// List of named z-index layers for Herman's layout.
 /// The order they are defined

--- a/scss/iframes/_base.scss
+++ b/scss/iframes/_base.scss
@@ -1,4 +1,4 @@
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 :root {
   line-height: tools.ratio('line-height');

--- a/scss/iframes/_color.scss
+++ b/scss/iframes/_color.scss
@@ -1,7 +1,7 @@
 // Preview Layouts
 // ===============
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 // Color Preview
 // -------------

--- a/scss/iframes/_font.scss
+++ b/scss/iframes/_font.scss
@@ -1,4 +1,4 @@
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 [data-herman-preview='font'] {
   --herman-label-color: #{tools.color('slight')};

--- a/scss/iframes/_size.scss
+++ b/scss/iframes/_size.scss
@@ -1,4 +1,4 @@
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 [data-herman-size='overflow'] {
   max-width: 100%;

--- a/scss/initial/_icons.scss
+++ b/scss/initial/_icons.scss
@@ -1,7 +1,7 @@
 // Icons
 // =====
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 /// # Herman Icons
 /// Herman doesn't use very many icons internally…

--- a/scss/initial/_root.scss
+++ b/scss/initial/_root.scss
@@ -1,7 +1,7 @@
 // Root Typography
 // ===============
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 @use '../config';
 
 /// # Herman Typography

--- a/scss/initial/_sample-previews.scss
+++ b/scss/initial/_sample-previews.scss
@@ -1,7 +1,7 @@
 // Sample Previews
 // ===============
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 @use '../samples/colors';
 
 // Add color sample CSS custom properties

--- a/scss/layout/_banner.scss
+++ b/scss/layout/_banner.scss
@@ -1,7 +1,7 @@
 // Banner Styles
 // =============
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 @use '../config';
 
 // Banner Region

--- a/scss/layout/_main.scss
+++ b/scss/layout/_main.scss
@@ -4,7 +4,7 @@
 /// Styles related to the main content area in generated Herman docs.
 /// @group style-main
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 // Main Region
 // -----------

--- a/scss/layout/_nav.scss
+++ b/scss/layout/_nav.scss
@@ -4,7 +4,7 @@
 /// Styles related to the navigation sidebar in generated Herman docs.
 /// @group style-nav
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 @use '../config';
 
 // Nav Region

--- a/scss/layout/_regions.scss
+++ b/scss/layout/_regions.scss
@@ -6,7 +6,7 @@
 /// as well as the `app` and `container` wrapping regions.
 /// @group style-regions
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 // General
 // -------

--- a/scss/patterns/_forms.scss
+++ b/scss/patterns/_forms.scss
@@ -1,7 +1,7 @@
 // Forms
 // =====
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 ::placeholder {
   color: currentcolor;

--- a/scss/patterns/_type.scss
+++ b/scss/patterns/_type.scss
@@ -1,7 +1,7 @@
 // Typography Patterns
 // ===================
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 @use '../config';
 
 // Text Blocks

--- a/scss/previews/_code.scss
+++ b/scss/previews/_code.scss
@@ -6,7 +6,7 @@
 /// @group style-code
 /// @link https://highlightjs.org/ Highlight.JS
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 // Code Blocks
 // -----------

--- a/scss/previews/_examples.scss
+++ b/scss/previews/_examples.scss
@@ -1,7 +1,7 @@
 // Examples
 // ========
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 .example {
   margin-bottom: tools.size('gutter');

--- a/scss/previews/_highlight.scss
+++ b/scss/previews/_highlight.scss
@@ -1,4 +1,4 @@
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 /// ## Syntax Highlighting
 ///

--- a/scss/previews/_icon.scss
+++ b/scss/previews/_icon.scss
@@ -1,7 +1,7 @@
 // Icon Preview
 // ============
 
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 [data-sassdoc='icon-preview'] {
   display: grid;

--- a/scss/samples/_colors.scss
+++ b/scss/samples/_colors.scss
@@ -1,6 +1,6 @@
 @use 'sass:meta';
 @use '../utilities';
-@use 'pkg:accoutrement/sass/tools';
+@use 'pkg:accoutrement' as tools;
 
 // Color Samples
 // =============
@@ -246,7 +246,7 @@ $demo-noncolors: (
 /// @colors demo-noncolors
 /// @example scss
 ///   @use 'sass:meta';
-///   @use 'pkg:accoutrement/sass/tools';
+///   @use 'pkg:accoutrement' as tools;
 ///   @use 'utilities';
 ///
 ///   utilities.$herman: ();

--- a/scss/samples/_colors.scss
+++ b/scss/samples/_colors.scss
@@ -247,25 +247,26 @@ $demo-noncolors: (
 /// @example scss
 ///   @use 'sass:meta';
 ///   @use 'pkg:accoutrement' as tools;
-///   @use 'utilities';
+///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   @use 'utilities' as herman;
 ///
-///   utilities.$herman: ();
+///   herman.$herman: ();
 ///   $demo-noncolors: (
 ///     'light-gray': '#brand-blue' ('tint': 80%, 'desaturate': 80%),
 ///     'gray': '#brand-blue' ('desaturate': 80%),
 ///     'black': '#brand-blue' ('shade': 30%, 'desaturate': 80%),
 ///   );
 ///
-///   $compiled: utilities.each-key(
+///   $compiled: herman.each-key(
 ///     $demo-noncolors,
 ///     meta.get-function('color', $module: 'tools'),
 ///   );
 ///
-///   @include utilities.add(
+///   @include herman.add(
 ///     'colors', 'demo-noncolors', $compiled,
 ///   );
 ///
-///   @each $key, $value in utilities.$herman {
+///   @each $key, $value in herman.$herman {
 ///   /* #{$key}: #{meta.inspect($value)} */
 ///   }
 /// @group demo_colors

--- a/scss/samples/_colors.scss
+++ b/scss/samples/_colors.scss
@@ -247,7 +247,9 @@ $demo-noncolors: (
 /// @example scss
 ///   @use 'sass:meta';
 ///   @use 'pkg:accoutrement' as tools;
-///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   // To import from Herman installed via npm,
+///   // replace the following 'utilities' import with:
+///   // @use 'pkg:sassdoc-theme-herman' as herman;
 ///   @use 'utilities' as herman;
 ///
 ///   herman.$herman: ();

--- a/scss/samples/_examples.scss
+++ b/scss/samples/_examples.scss
@@ -75,25 +75,9 @@
 ///         - 'node_modules'
 /// ```
 ///
-/// You can also set an array of default `includes` or `use`
+/// You can also set an array of default files
 /// (relative to any `loadPaths`)
-/// to include for all Sass examples:
-///
-/// To `@import` files:
-///
-/// ```yaml
-/// # .sassdocrc (yaml)
-/// herman:
-///   sass:
-///     sassOptions:
-///       loadPaths:
-///         - 'static/sass'
-///     includes:
-///       - 'utilities'
-///       - 'config'
-/// ```
-///
-/// Or to `@use` files:
+/// to `@use` for all Sass examples:
 ///
 /// ```yaml
 /// # .sassdocrc (yaml)

--- a/scss/utilities/_json-api.scss
+++ b/scss/utilities/_json-api.scss
@@ -28,7 +28,9 @@
 /// @see export
 ///
 /// @example scss
-///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   // To import from Herman installed via npm,
+///   // replace the following 'utilities' import with:
+///   // @use 'pkg:sassdoc-theme-herman' as herman;
 ///   @use 'utilities' as herman;
 ///
 ///   herman.$herman: (
@@ -167,7 +169,9 @@
 /// @group api_json-export
 ///
 /// @example scss - sample map structure
-///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   // To import from Herman installed via npm,
+///   // replace the following 'utilities' import with:
+///   // @use 'pkg:sassdoc-theme-herman' as herman;
 ///   @use 'utilities' as herman;
 ///
 ///   herman.$herman: (
@@ -217,7 +221,9 @@ $herman: () !default;
 ///   Map to be encoded for JSON exporting
 ///
 /// @example scss
-///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   // To import from Herman installed via npm,
+///   // replace the following 'utilities' import with:
+///   // @use 'pkg:sassdoc-theme-herman' as herman;
 ///   @use 'utilities' as herman;
 ///
 ///   // Export to JSON

--- a/scss/utilities/_json-api.scss
+++ b/scss/utilities/_json-api.scss
@@ -28,9 +28,10 @@
 /// @see export
 ///
 /// @example scss
-///   @use 'utilities';
+///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   @use 'utilities' as herman;
 ///
-///   utilities.$herman: (
+///   herman.$herman: (
 ///     'colors': (
 ///       'brand-colors': (
 ///         'brand-orange': #c75000,
@@ -39,7 +40,7 @@
 ///     ),
 ///   );
 ///
-///   @include utilities.export(utilities.$herman);
+///   @include herman.export(herman.$herman);
 
 // Herman
 // ------
@@ -166,9 +167,10 @@
 /// @group api_json-export
 ///
 /// @example scss - sample map structure
-///   @use 'utilities';
+///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   @use 'utilities' as herman;
 ///
-///   utilities.$herman: (
+///   herman.$herman: (
 ///     'colors': (
 ///       'brand-colors': (
 ///         'brand-orange': '#c75000',
@@ -215,10 +217,11 @@ $herman: () !default;
 ///   Map to be encoded for JSON exporting
 ///
 /// @example scss
-///   @use 'utilities';
+///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   @use 'utilities' as herman;
 ///
 ///   // Export to JSON
-///   @include utilities.export;
+///   @include herman.export;
 @mixin export($map: $herman) {
   /*! json-encode: #{json.encode($map)} */
 }

--- a/scss/utilities/_maps.scss
+++ b/scss/utilities/_maps.scss
@@ -42,7 +42,7 @@
 ///   Updated `$herman` map, ready for JSON export
 /// @example scss
 ///   @use 'sass:meta';
-///   @use 'pkg:accoutrement/sass/tools';
+///   @use 'pkg:accoutrement' as tools;
 ///   @use 'utilities';
 ///
 ///   utilities.$herman: ();
@@ -148,7 +148,7 @@
 ///   and converted to json-ready strings
 /// @example scss
 ///   @use 'sass:meta';
-///   @use 'pkg:accoutrement/sass/tools';
+///   @use 'pkg:accoutrement' as tools;
 ///   @use 'utilities';
 ///
 ///   $brand-colors: (

--- a/scss/utilities/_maps.scss
+++ b/scss/utilities/_maps.scss
@@ -43,7 +43,9 @@
 /// @example scss
 ///   @use 'sass:meta';
 ///   @use 'pkg:accoutrement' as tools;
-///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   // To import from Herman installed via npm,
+///   // replace the following 'utilities' import with:
+///   // @use 'pkg:sassdoc-theme-herman' as herman;
 ///   @use 'utilities' as herman;
 ///
 ///   herman.$herman: ();
@@ -150,7 +152,9 @@
 /// @example scss
 ///   @use 'sass:meta';
 ///   @use 'pkg:accoutrement' as tools;
-///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   // To import from Herman installed via npm,
+///   // replace the following 'utilities' import with:
+///   // @use 'pkg:sassdoc-theme-herman' as herman;
 ///   @use 'utilities' as herman;
 ///
 ///   $brand-colors: (

--- a/scss/utilities/_maps.scss
+++ b/scss/utilities/_maps.scss
@@ -43,20 +43,21 @@
 /// @example scss
 ///   @use 'sass:meta';
 ///   @use 'pkg:accoutrement' as tools;
-///   @use 'utilities';
+///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   @use 'utilities' as herman;
 ///
-///   utilities.$herman: ();
+///   herman.$herman: ();
 ///   $brand-colors: (
 ///     'brand-blue': hsl(195, 85%, 35%),
 ///     'light-gray': '#brand-blue' ('tint': 80%, 'desaturate': 80%),
 ///   );
-///   $brand-compiled: utilities.each-key(
+///   $brand-compiled: herman.each-key(
 ///     $brand-colors,
 ///     meta.get-function('color', $module: 'tools'),
 ///   );
-///   @include utilities.add('colors', 'brand-colors', $brand-compiled);
+///   @include herman.add('colors', 'brand-colors', $brand-compiled);
 ///
-///   @each $key, $value in utilities.$herman {
+///   @each $key, $value in herman.$herman {
 ///   /* #{$key}: #{meta.inspect($value)} */
 ///   }
 @mixin add($type, $key, $map) {
@@ -149,14 +150,15 @@
 /// @example scss
 ///   @use 'sass:meta';
 ///   @use 'pkg:accoutrement' as tools;
-///   @use 'utilities';
+///   // Replace next line with: `@use 'pkg:sassdoc-theme-herman' as herman;`
+///   @use 'utilities' as herman;
 ///
 ///   $brand-colors: (
 ///     'brand-orange': hsl(24, 100%, 39%),
 ///     'brand-blue': hsl(195, 85%, 35%),
 ///     'light-gray': 'brand-blue' ('tint': 80%, 'desaturate': 80%),
 ///   );
-///   $compiled: utilities.each-key($brand-colors, meta.get-function('color', $module: 'tools'));
+///   $compiled: herman.each-key($brand-colors, meta.get-function('color', $module: 'tools'));
 ///
 ///   @each $key, $value in $compiled {
 ///   /* #{$key}: #{$value} */

--- a/test/js/testAnnotations.js
+++ b/test/js/testAnnotations.js
@@ -1334,6 +1334,63 @@ describe('example annotation', () => {
         .catch(done);
     });
 
+    it('uses custom `sass.implementation` string [sass-embedded]', function (done) {
+      const data = [
+        {
+          example: [
+            {
+              type: 'scss',
+              code: '/* just a placeholder */',
+            },
+          ],
+        },
+      ];
+      const env = Object.assign({}, this.env, {
+        herman: {
+          sass: {
+            implementation: 'sass-embedded',
+          },
+        },
+      });
+      const example = annotations.example(env);
+      example
+        .resolve(data)
+        .then(() => {
+          assert.equal(data[0].example[0].rendered, data[0].example[0].code);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('custom `sass.implementation` instance [sass-embedded]', function (done) {
+      const data = [
+        {
+          example: [
+            {
+              type: 'scss',
+              code: '/* just a placeholder */',
+            },
+          ],
+        },
+      ];
+      const env = Object.assign({}, this.env, {
+        herman: {
+          sass: {
+            // eslint-disable-next-line global-require
+            implementation: require('sass-embedded'),
+          },
+        },
+      });
+      const example = annotations.example(env);
+      example
+        .resolve(data)
+        .then(() => {
+          assert.equal(data[0].example[0].rendered, data[0].example[0].code);
+          done();
+        })
+        .catch(done);
+    });
+
     it('skips non-html, non-njk, non-scss items', function (done) {
       const data = [
         {

--- a/test/js/testAnnotations.js
+++ b/test/js/testAnnotations.js
@@ -1223,40 +1223,6 @@ describe('example annotation', () => {
         .catch(done);
     });
 
-    it('injects global imports for scss items [import]', function (done) {
-      const data = [
-        {
-          example: [
-            {
-              type: 'scss',
-              code: 'body { @include color; }',
-            },
-          ],
-        },
-      ];
-      const env = Object.assign({}, this.env, {
-        herman: {
-          sass: {
-            includes: ['pkg:accoutrement/sass/color', 'import', 'tools'],
-            sassOptions: {
-              loadPaths: [path.join(__dirname, 'fixtures', 'scss')],
-            },
-          },
-        },
-      });
-      const example = annotations.example(env);
-      example
-        .resolve(data)
-        .then(() => {
-          assert.strictEqual(
-            data[0].example[0].rendered,
-            `body {\n  border: 1px;\n}\n\nbody {\n  color: red;\n}`,
-          );
-          done();
-        })
-        .catch(done);
-    });
-
     it('injects global imports for scss items [use]', function (done) {
       const data = [
         {
@@ -1310,16 +1276,18 @@ describe('example annotation', () => {
       const env = Object.assign({}, this.env, {
         herman: {
           sass: {
-            importers: [
-              {
-                findFileUrl: () =>
-                  new URL(
-                    pathToFileURL(
-                      path.join(__dirname, 'fixtures', 'scss', 'import'),
+            sassOptions: {
+              importers: [
+                {
+                  findFileUrl: () =>
+                    new URL(
+                      pathToFileURL(
+                        path.join(__dirname, 'fixtures', 'scss', 'import'),
+                      ),
                     ),
-                  ),
-              },
-            ],
+                },
+              ],
+            },
           },
         },
       });

--- a/test/sass/test_sass.js
+++ b/test/sass/test_sass.js
@@ -2,10 +2,7 @@
 
 const path = require('path');
 
-const { NodePackageImporter } = require('sass');
 const sassTrue = require('sass-true');
 
 const sassFile = path.join(__dirname, 'test.scss');
-sassTrue.runSass({ describe, it }, sassFile, {
-  importers: [new NodePackageImporter()],
-});
+sassTrue.runSass({ describe, it, sass: 'sass-embedded' }, sassFile);

--- a/test/sass/utilities/_json-api.scss
+++ b/test/sass/utilities/_json-api.scss
@@ -1,7 +1,7 @@
 // JSON Export Tests
 // =================
 
-@use 'true';
+@use 'pkg:sass-true' as true;
 @use '../../../scss/utilities/json-api' as *;
 @use '../../../scss/utilities/json-encode' as json;
 

--- a/test/sass/utilities/_json-encode.scss
+++ b/test/sass/utilities/_json-encode.scss
@@ -1,7 +1,7 @@
 // JSON Encoding Tests
 // ===================
 
-@use 'true';
+@use 'pkg:sass-true' as true;
 @use '../../../scss/utilities/json-encode' as *;
 
 // JSON Encode

--- a/test/sass/utilities/_maps.scss
+++ b/test/sass/utilities/_maps.scss
@@ -5,7 +5,7 @@
 @use 'sass:map';
 @use 'sass:meta';
 @use 'true';
-@use 'pkg:accoutrement/sass/tools' with (
+@use 'pkg:accoutrement' as tools with (
   $functions: (
     'darken': meta.get-function('darken'),
     'desaturate': meta.get-function('desaturate'),

--- a/test/sass/utilities/_maps.scss
+++ b/test/sass/utilities/_maps.scss
@@ -4,7 +4,7 @@
 @use 'sass:color';
 @use 'sass:map';
 @use 'sass:meta';
-@use 'true';
+@use 'pkg:sass-true' as true;
 @use 'pkg:accoutrement' as tools with (
   $functions: (
     'darken': meta.get-function('darken'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const path = require('path');
 
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const { NodePackageImporter } = require('sass');
+const sass = require('sass-embedded');
 const webpack = require('webpack');
 
 const SassDocPlugin = require('./sassdoc-webpack-plugin');
@@ -39,6 +39,7 @@ const sassDocOpts = {
       templatePath: path.join(__dirname, 'templates'),
     },
     sass: {
+      implementation: sass,
       use: ['config', 'samples'],
       sassOptions: {
         loadPaths: [path.join(__dirname, 'scss')],
@@ -202,10 +203,11 @@ module.exports = {
           {
             loader: 'sass-loader',
             options: {
+              implementation: sass,
               api: 'modern',
               sourceMap: true,
               sassOptions: {
-                importers: [new NodePackageImporter()],
+                importers: [new sass.NodePackageImporter()],
               },
             },
           },
@@ -220,9 +222,10 @@ module.exports = {
           {
             loader: 'sass-loader',
             options: {
+              implementation: sass,
               api: 'modern',
               sassOptions: {
-                importers: [new NodePackageImporter()],
+                importers: [new sass.NodePackageImporter()],
               },
             },
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adobe/css-tools@npm:^4.3.2":
+"@adobe/css-tools@npm:^4.3.2, @adobe/css-tools@npm:^4.3.3":
   version: 4.3.3
   resolution: "@adobe/css-tools@npm:4.3.3"
   checksum: 10/0e77057efb4e18182560855503066b75edca98671be327d3f8a7ae89ec3da6821e693114b55225909fca00d7e7ed8422f3d79d71fe95dd4d5df1f2026a9fda02
@@ -2121,12 +2121,12 @@ __metadata:
   linkType: hard
 
 "@types/eslint@npm:*":
-  version: 8.56.2
-  resolution: "@types/eslint@npm:8.56.2"
+  version: 8.56.3
+  resolution: "@types/eslint@npm:8.56.3"
   dependencies:
     "@types/estree": "npm:*"
     "@types/json-schema": "npm:*"
-  checksum: 10/9e4805e770ea90a561e1f69e5edce28b8f66e92e290705100e853c7c252cf87bef654168d0d47fc60c0effbe4517dd7a8d2fa6d3f04c7f831367d568009fd368
+  checksum: 10/b5a006c24b5d3a2dba5acc12f21f96c960836beb08544cfedbbbd5b7770b6c951b41204d676b73d7d9065bef3435e5b4cb3796c57f66df21c12fd86018993a16
   languageName: node
   linkType: hard
 
@@ -2269,11 +2269,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 20.11.19
-  resolution: "@types/node@npm:20.11.19"
+  version: 20.11.20
+  resolution: "@types/node@npm:20.11.20"
   dependencies:
     undici-types: "npm:~5.26.4"
-  checksum: 10/c7f4705d6c84aa21679ad180c33c13ca9567f650e66e14bcee77c7c43d14619c7cd3b4d7b2458947143030b7b1930180efa6d12d999b45366abff9fed7a17472
+  checksum: 10/ff449bdc94810dadb54e0f77dd587c6505ef79ffa5a208c16eb29b223365b188f4c935a3abaf0906a01d05257c3da1f72465594a841d35bcf7b6deac7a6938fb
   languageName: node
   linkType: hard
 
@@ -3700,9 +3700,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001578, caniuse-lite@npm:^1.0.30001587":
-  version: 1.0.30001588
-  resolution: "caniuse-lite@npm:1.0.30001588"
-  checksum: 10/09150ef2daa65c75cb2681832d5bc203760a02d9f71eb033dc0401fbfdbe026d3a84e54a8d2085f730a4f51eb074028b89013dd033841e1a0eb3c7323a50ed45
+  version: 1.0.30001589
+  resolution: "caniuse-lite@npm:1.0.30001589"
+  checksum: 10/5e1d2eb7c32d48c52204227bc1377f0f4c758ef889c53b9b479e28470e7f82eb1db5853e7754be9600ee662ae32a1d58e8bef0fde6edab06322ddbabfd9d212f
   languageName: node
   linkType: hard
 
@@ -4540,18 +4540,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-default@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "cssnano-preset-default@npm:6.0.3"
+"cssnano-preset-default@npm:^6.0.4":
+  version: 6.0.4
+  resolution: "cssnano-preset-default@npm:6.0.4"
   dependencies:
     css-declaration-sorter: "npm:^7.1.1"
     cssnano-utils: "npm:^4.0.1"
     postcss-calc: "npm:^9.0.1"
     postcss-colormin: "npm:^6.0.2"
-    postcss-convert-values: "npm:^6.0.2"
+    postcss-convert-values: "npm:^6.0.3"
     postcss-discard-comments: "npm:^6.0.1"
-    postcss-discard-duplicates: "npm:^6.0.1"
-    postcss-discard-empty: "npm:^6.0.1"
+    postcss-discard-duplicates: "npm:^6.0.2"
+    postcss-discard-empty: "npm:^6.0.2"
     postcss-discard-overridden: "npm:^6.0.1"
     postcss-merge-longhand: "npm:^6.0.2"
     postcss-merge-rules: "npm:^6.0.3"
@@ -4575,7 +4575,7 @@ __metadata:
     postcss-unique-selectors: "npm:^6.0.2"
   peerDependencies:
     postcss: ^8.4.31
-  checksum: 10/95f5f7f6f09abdcc21434c7a624017a450848bd4d97f4899e74bda3c6011c3dfce0b58f499a24f7e78eb218a26af27c5e12ab663f2b272c73448f55d3a9a4a12
+  checksum: 10/65269604c41fcbc08508c644d660cfb0aaf9805ce5cd18fb706a7f87af558a4b6a3578324ead4838afb8b494a54d6e476cad3569ae6ba573b86ebb0d263dd7cd
   languageName: node
   linkType: hard
 
@@ -4589,14 +4589,14 @@ __metadata:
   linkType: hard
 
 "cssnano@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "cssnano@npm:6.0.3"
+  version: 6.0.4
+  resolution: "cssnano@npm:6.0.4"
   dependencies:
-    cssnano-preset-default: "npm:^6.0.3"
-    lilconfig: "npm:^3.0.0"
+    cssnano-preset-default: "npm:^6.0.4"
+    lilconfig: "npm:^3.1.1"
   peerDependencies:
     postcss: ^8.4.31
-  checksum: 10/2b30ce0d9ba337737f4c6af4b6731dd5031cc4e1414a43b87ddb20fd9903a4f5b41182cc6a4b98cc82ca7975ecaa4b8ac487bd34f698998404c5ed0944914a6b
+  checksum: 10/b6a94cfa93115d01c290773a818d7247e63e7021e3d14749510daf7858f4d40a6bf20bdee852a64d4cec6554c3f3b9d5164a3bdf3db5cf15059c2b533c63026a
   languageName: node
   linkType: hard
 
@@ -5091,9 +5091,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.668":
-  version: 1.4.678
-  resolution: "electron-to-chromium@npm:1.4.678"
-  checksum: 10/879f3ab8022f2c8c8b5a3b1b164a54bfd195d50091051da2062ee73ae912d73f7a937daf9b58ec54c30d0149d03eb8ee1e6d1b24033f00bfe8f5f7d2142bd0ce
+  version: 1.4.680
+  resolution: "electron-to-chromium@npm:1.4.680"
+  checksum: 10/833b78d38408a1846c74798a9d5be07ed17d5d17aae5c48802dd1199a1aa90e2df8b0f4369fdabc12b38be8c6ccce4b2b6f2cae3978ca372c25ee380de9c949c
   languageName: node
   linkType: hard
 
@@ -8614,7 +8614,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lilconfig@npm:^3.0.0":
+"lilconfig@npm:^3.1.1":
   version: 3.1.1
   resolution: "lilconfig@npm:3.1.1"
   checksum: 10/c80fbf98ae7d1daf435e16a83fe3c63743b9d92804cac6dc53ee081c7c265663645c3162d8a0d04ff1874f9c07df145519743317dee67843234c6ed279300f83
@@ -9878,11 +9878,11 @@ __metadata:
   linkType: hard
 
 "npm-run-path@npm:^5.1.0":
-  version: 5.2.0
-  resolution: "npm-run-path@npm:5.2.0"
+  version: 5.3.0
+  resolution: "npm-run-path@npm:5.3.0"
   dependencies:
     path-key: "npm:^4.0.0"
-  checksum: 10/c5325e016014e715689c4014f7e0be16cc4cbf529f32a1723e511bc4689b5f823b704d2bca61ac152ce2bda65e0205dc8b3ba0ec0f5e4c3e162d302f6f5b9efb
+  checksum: 10/ae8e7a89da9594fb9c308f6555c73f618152340dcaae423e5fb3620026fefbec463618a8b761920382d666fa7a2d8d240b6fe320e8a6cdd54dc3687e2b659d25
   languageName: node
   linkType: hard
 
@@ -10542,15 +10542,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-convert-values@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "postcss-convert-values@npm:6.0.2"
+"postcss-convert-values@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "postcss-convert-values@npm:6.0.3"
   dependencies:
     browserslist: "npm:^4.22.2"
     postcss-value-parser: "npm:^4.2.0"
   peerDependencies:
     postcss: ^8.4.31
-  checksum: 10/07fcb993490c3533a55d7145fbf40b6d32dd4867ca7491c0b61e9c1301693b378cb734505a41d13d33836140ee9cf0e05f97cbfc40a2c01058bdcb17ea474d9a
+  checksum: 10/606e02e8a1e739b0c2becb1ad145154b3c819dc2d57bacfa74362fb88c6a7f186e5da6ab3c6b10a1525d8353e5bc5607af98822a23703947d6fd14cee3f75baf
   languageName: node
   linkType: hard
 
@@ -10563,21 +10563,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-discard-duplicates@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "postcss-discard-duplicates@npm:6.0.1"
+"postcss-discard-duplicates@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "postcss-discard-duplicates@npm:6.0.2"
   peerDependencies:
     postcss: ^8.4.31
-  checksum: 10/5102e845630578b71fc9a2c6ed9941e6b96025b0decb7da2026318c3144ed562bdccdb33b6f687424caba389c84a525bf205d4020ff2d8fdcacef25b292bed84
+  checksum: 10/918ed7eeb537a955172c73a3dfbcde57fd6515a4c993dfe65a4fe5c4f1d7eda07a3811f73b7d6c6b29d9ba1e6a15e77366866335cb56841777387d482a55e6a8
   languageName: node
   linkType: hard
 
-"postcss-discard-empty@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "postcss-discard-empty@npm:6.0.1"
+"postcss-discard-empty@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "postcss-discard-empty@npm:6.0.2"
   peerDependencies:
     postcss: ^8.4.31
-  checksum: 10/d60fdecd84af6254d87e8947522c8a82e72c28084e4e3bc7d5e1157926e31abee16af08d61716545370dc34e034dfd226468e96579b8aab51b6911f4cc21288e
+  checksum: 10/3eed50fb937a68a01a051ea8824b89879b31f31e3061322e74f747240141f2447c760bd029493d942be5ec2d383cf393c2d281556e3de0f93c9ceec2a0cbb760
   languageName: node
   linkType: hard
 
@@ -12007,16 +12007,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-true@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "sass-true@npm:7.0.1"
+"sass-true@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "sass-true@npm:8.0.0"
   dependencies:
-    "@adobe/css-tools": "npm:^4.3.2"
+    "@adobe/css-tools": "npm:^4.3.3"
     jest-diff: "npm:^29.7.0"
     lodash: "npm:^4.17.21"
-  peerDependencies:
-    sass: ">=1.45.0"
-  checksum: 10/7a94959aac180bb8bec75f0c1f29c5745e7d735d80370349fc2e47a7e911b19eeb37894a1030da6f74950892f1229ae4e56555386203df41a4262e57750c0660
+  checksum: 10/2251a50dca8ee28b6fcb13241e48077ea7c651cf4006abd78e397ebad12ef6dcc9a89c6d5a0b3bc6ba1c5d0e4f75a54f5aa9cc256b41d8861bea3a2399181796
   languageName: node
   linkType: hard
 
@@ -12132,7 +12130,7 @@ __metadata:
     sass: "npm:^1.71.1"
     sass-embedded: "npm:^1.71.1"
     sass-loader: "npm:^14.1.1"
-    sass-true: "npm:^7.0.1"
+    sass-true: "npm:^8.0.0"
     sassdoc: "npm:^2.7.4"
     sassdoc-extras: "npm:^3.0.0"
     sinon: "npm:^17.0.1"
@@ -12565,12 +12563,12 @@ __metadata:
   linkType: hard
 
 "socks@npm:^2.7.1":
-  version: 2.8.0
-  resolution: "socks@npm:2.8.0"
+  version: 2.8.1
+  resolution: "socks@npm:2.8.1"
   dependencies:
     ip-address: "npm:^9.0.5"
     smart-buffer: "npm:^4.2.0"
-  checksum: 10/ed0224ce2c7daaa7690cb87cf53d9703ffc4e983aca221f6f5b46767b232658df49494fd86acd0bf97ada6de05248ea8ea625c2343d48155d8463fc40d4a340f
+  checksum: 10/a3cc38e0716ab53a2db3fa00c703ca682ad54dbbc9ed4c7461624a999be6fa7cdc79fc904c411618e698d5eff55a55aa6d9329169a7db11636d0200814a2b5aa
   languageName: node
   linkType: hard
 
@@ -13274,8 +13272,8 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.26.0":
-  version: 5.27.2
-  resolution: "terser@npm:5.27.2"
+  version: 5.28.1
+  resolution: "terser@npm:5.28.1"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.8.2"
@@ -13283,7 +13281,7 @@ __metadata:
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 10/589f1112d6cd7653f6e2d4a38970e97a160de01cddb214dc924aa330c22b8c3635067a47db1233e060e613e380b979ca336c3211b17507ea13b0adff10ecbd40
+  checksum: 10/922159f036a89a7d01b8b67e0eacb4425c20cf19067d2e82c1523153ed3bf66c36b945fd16c610b7ea41fedb867b189d2a350415fb566f4668a1701ab768728e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,6 +1373,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bufbuild/protobuf@npm:^1.0.0":
+  version: 1.7.2
+  resolution: "@bufbuild/protobuf@npm:1.7.2"
+  checksum: 10/f23ccc77066100157043cf36bd2506acdcb235f0a902f7662fbbb992e78df4202780aeb55bd2e3fd1945bd9e52a4fca759351f333f2ff779e32996e13eb56d34
+  languageName: node
+  linkType: hard
+
 "@csstools/css-parser-algorithms@npm:^2.5.0":
   version: 2.6.0
   resolution: "@csstools/css-parser-algorithms@npm:2.6.0"
@@ -3532,6 +3539,13 @@ __metadata:
   dependencies:
     node-int64: "npm:^0.4.0"
   checksum: 10/edba1b65bae682450be4117b695997972bd9a3c4dfee029cab5bcb72ae5393a79a8f909b8bc77957eb0deec1c7168670f18f4d5c556f46cdd3bca5f3b3a8d020
+  languageName: node
+  linkType: hard
+
+"buffer-builder@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "buffer-builder@npm:0.2.0"
+  checksum: 10/16bd9eb8ac6630a05441bcb56522e956ae6a0724371ecc49b9a6bc10d35690489140df73573d0577e1e85c875737e560a4e2e67521fddd14714ddf4e0097d0ec
   languageName: node
   linkType: hard
 
@@ -11685,6 +11699,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.4.0":
+  version: 7.8.1
+  resolution: "rxjs@npm:7.8.1"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10/b10cac1a5258f885e9dd1b70d23c34daeb21b61222ee735d2ec40a8685bdca40429000703a44f0e638c27a684ac139e1c37e835d2a0dc16f6fc061a138ae3abb
+  languageName: node
+  linkType: hard
+
 "safe-array-concat@npm:^1.1.0":
   version: 1.1.0
   resolution: "safe-array-concat@npm:1.1.0"
@@ -11756,6 +11779,205 @@ __metadata:
     through2: "npm:^2.0.0"
     which: "npm:^1.0.5"
   checksum: 10/9c62c38696d34d27c6983a5b9597bb6c8bf49bfe0d2e7cb12bba54c3da1bd4ec76c486dbb217192976ce7a30388858f164170461b437fe46973a78dfaf55dc73
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-arm64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-android-arm64@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-arm@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-android-arm@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-ia32@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-android-ia32@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=android & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"sass-embedded-android-x64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-android-x64@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-darwin-arm64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-darwin-arm64@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-darwin-x64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-darwin-x64@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-arm64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-linux-arm64@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-arm@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-linux-arm@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-ia32@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-linux-ia32@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-arm64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-linux-musl-arm64@npm:1.71.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-arm@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-linux-musl-arm@npm:1.71.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-ia32@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-linux-musl-ia32@npm:1.71.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-musl-x64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-linux-musl-x64@npm:1.71.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-linux-x64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-linux-x64@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"sass-embedded-win32-ia32@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-win32-ia32@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass.bat
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"sass-embedded-win32-x64@npm:1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded-win32-x64@npm:1.71.1"
+  bin:
+    sass: dart-sass/sass.bat
+  conditions: os=win32 & (cpu=arm64 | cpu=x64)
+  languageName: node
+  linkType: hard
+
+"sass-embedded@npm:^1.71.1":
+  version: 1.71.1
+  resolution: "sass-embedded@npm:1.71.1"
+  dependencies:
+    "@bufbuild/protobuf": "npm:^1.0.0"
+    buffer-builder: "npm:^0.2.0"
+    immutable: "npm:^4.0.0"
+    rxjs: "npm:^7.4.0"
+    sass-embedded-android-arm: "npm:1.71.1"
+    sass-embedded-android-arm64: "npm:1.71.1"
+    sass-embedded-android-ia32: "npm:1.71.1"
+    sass-embedded-android-x64: "npm:1.71.1"
+    sass-embedded-darwin-arm64: "npm:1.71.1"
+    sass-embedded-darwin-x64: "npm:1.71.1"
+    sass-embedded-linux-arm: "npm:1.71.1"
+    sass-embedded-linux-arm64: "npm:1.71.1"
+    sass-embedded-linux-ia32: "npm:1.71.1"
+    sass-embedded-linux-musl-arm: "npm:1.71.1"
+    sass-embedded-linux-musl-arm64: "npm:1.71.1"
+    sass-embedded-linux-musl-ia32: "npm:1.71.1"
+    sass-embedded-linux-musl-x64: "npm:1.71.1"
+    sass-embedded-linux-x64: "npm:1.71.1"
+    sass-embedded-win32-ia32: "npm:1.71.1"
+    sass-embedded-win32-x64: "npm:1.71.1"
+    supports-color: "npm:^8.1.1"
+    varint: "npm:^6.0.0"
+  dependenciesMeta:
+    sass-embedded-android-arm:
+      optional: true
+    sass-embedded-android-arm64:
+      optional: true
+    sass-embedded-android-ia32:
+      optional: true
+    sass-embedded-android-x64:
+      optional: true
+    sass-embedded-darwin-arm64:
+      optional: true
+    sass-embedded-darwin-x64:
+      optional: true
+    sass-embedded-linux-arm:
+      optional: true
+    sass-embedded-linux-arm64:
+      optional: true
+    sass-embedded-linux-ia32:
+      optional: true
+    sass-embedded-linux-musl-arm:
+      optional: true
+    sass-embedded-linux-musl-arm64:
+      optional: true
+    sass-embedded-linux-musl-ia32:
+      optional: true
+    sass-embedded-linux-musl-x64:
+      optional: true
+    sass-embedded-linux-x64:
+      optional: true
+    sass-embedded-win32-ia32:
+      optional: true
+    sass-embedded-win32-x64:
+      optional: true
+  checksum: 10/bf4da1bf905b7de845822c915169e35c6fb9f4e9055b4042f5869b3ed7c803b13017c408b0a068279a9240b2bd464609e77744f4bd163580c23997cd67d82b91
   languageName: node
   linkType: hard
 
@@ -11908,6 +12130,7 @@ __metadata:
     prettier: "npm:^3.2.5"
     readable-stream: "npm:^4.5.2"
     sass: "npm:^1.71.1"
+    sass-embedded: "npm:^1.71.1"
     sass-loader: "npm:^14.1.1"
     sass-true: "npm:^7.0.1"
     sassdoc: "npm:^2.7.4"
@@ -12886,7 +13109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:8.1.1, supports-color@npm:^8.0.0":
+"supports-color@npm:8.1.1, supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -13241,7 +13464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.6.2":
+"tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10/bd26c22d36736513980091a1e356378e8b662ded04204453d353a7f34a4c21ed0afc59b5f90719d4ba756e581a162ecbf93118dc9c6be5acf70aa309188166ca
@@ -13656,6 +13879,13 @@ __metadata:
   version: 4.0.0
   resolution: "value-or-function@npm:4.0.0"
   checksum: 10/16b6aed84b8f9732a7eb7a5035a1480be3689d097a73b1154fb827caf021d5f2b6f60c0dfe694bfc8c9605f06cfc093dc428efdc3d24cb2768fbe202ffd42ae1
+  languageName: node
+  linkType: hard
+
+"varint@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "varint@npm:6.0.0"
+  checksum: 10/7684113c9d497c01e40396e50169c502eb2176203219b96e1c5ac965a3e15b4892bd22b7e48d87148e10fffe638130516b6dbeedd0efde2b2d0395aa1772eea7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&2124)

- uses the shared resources compiler for `@example` annotations
- adds `NodePackageImporter` by default
- allows using sass-embedded for `@example` annotations
- uses sass-embedded internally throughout, except for the Sass tests (requires a change to True) -- local build time decrease from ~15sec to ~9sec